### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/build-arcade-web.yml
+++ b/.github/workflows/build-arcade-web.yml
@@ -8,7 +8,13 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build-web:
@@ -30,15 +36,22 @@ jobs:
       - name: Build Arcade web bundle
         run: pygbag --html --build simulation
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: arcade-web-build
           path: simulation/build/web
-          if-no-files-found: error
+          retention-days: 1
 
-      - name: "Upload to GitHub pages branch gh-pages"
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages
-          folder: simulation/build/web
+  deploy:
+    needs: build-web
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build-arcade-web.yml
+++ b/.github/workflows/build-arcade-web.yml
@@ -43,6 +43,7 @@ jobs:
           retention-days: 1
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-web
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- switch the GitHub Pages workflow to upload the web build as a Pages artifact
- deploy the artifact with the official actions/deploy-pages workflow and set required permissions
- add concurrency control for Pages deployments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a25fbfa88327addf8484d0d3f7f6