### PR TITLE
Add AGENTS guidance and default logic unit test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines
+
+## Build & Packaging
+- Always create isolated Python environments targeting **Python 3.11** before installing dependencies.
+- Install runtime and build dependencies with `pip install -r requirements.txt`.
+- Use the non-interactive pygbag build pipeline to generate browser artifacts: `python -m pygbag --build simulation`. Do **not** run `pygbag simulation` directly because it blocks on the interactive deploy step.
+- When packaging for distribution, prefer `python -m build` after ensuring the virtual environment is active.
+
+## Testing
+- Run the unit test suite with `python -m unittest discover -s tests -p "test_*.py"`.
+- Add new tests alongside implementation changes whenever possible to keep coverage healthy.
+- Tests may import helpers from `simulation.logic` to validate simulation logic.
+
+## Code Quality
+- Follow the existing logging callbacks when reporting status or errors.
+- Avoid introducing new third-party dependencies unless they are already declared in `requirements.txt`.
+- Keep the codebase compatible with Unity's Python embedding constraints.

--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -1,0 +1,3 @@
+"""Simulation package exposing mesh coordination demos."""
+
+__all__ = ["logic"]

--- a/simulation/logic/__init__.py
+++ b/simulation/logic/__init__.py
@@ -1,0 +1,20 @@
+"""Core logic utilities for the Compotastic simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LogicProbe:
+    """Lightweight object used to verify simulation logic imports."""
+
+    name: str = "simulation.logic"
+
+    def is_available(self) -> bool:
+        """Return True to indicate the logic module is importable."""
+
+        return True
+
+
+__all__ = ["LogicProbe"]

--- a/tests/test_logic_probe.py
+++ b/tests/test_logic_probe.py
@@ -1,0 +1,14 @@
+import unittest
+
+from simulation.logic import LogicProbe
+
+
+class LogicProbeTests(unittest.TestCase):
+    def test_probe_reports_available(self) -> None:
+        probe = LogicProbe()
+        self.assertTrue(probe.is_available())
+        self.assertEqual("simulation.logic", probe.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add root AGENTS.md describing build, packaging, and testing workflows
- expose the simulation.logic package with a LogicProbe helper for import validation
- add a default unittest that exercises the simulation.logic module

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d7a6b97a848327afef964b3081e13c