### PR TITLE
Add pytest workflow job before build

### DIFF
--- a/.github/workflows/build-arcade-web.yml
+++ b/.github/workflows/build-arcade-web.yml
@@ -17,7 +17,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  test-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        run: PYTHONPATH=. pytest
+
   build-web:
+    needs: test-suite
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- add a dedicated test-suite job that installs dependencies and runs pytest
- make the existing build-web job depend on the test-suite so builds only run after tests succeed

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7ab32829883279e58025cc8255254