### PR TITLE
Disable beforeunload prompt in web build

### DIFF
--- a/simulation/main.py
+++ b/simulation/main.py
@@ -1,9 +1,35 @@
 import asyncio
+import importlib.util
+from typing import Any, Optional
+
 import pygame
+
+
+def _disable_beforeunload_prompt() -> None:
+    """Remove the default browser prompt about unsaved changes."""
+
+    js_spec = importlib.util.find_spec("js")
+    if js_spec is None:
+        return
+
+    from js import window  # type: ignore[attr-defined]
+
+    remove_event_listener: Optional[Any]
+    remove_event_listener = getattr(window, "removeEventListener", None)
+    previous_handler: Optional[Any]
+    previous_handler = getattr(window, "onbeforeunload", None)
+
+    if callable(remove_event_listener) and previous_handler is not None:
+        remove_event_listener("beforeunload", previous_handler)
+
+    window.onbeforeunload = None
+
 
 pygame.init()
 pygame.display.set_mode((320, 240))
 clock = pygame.time.Clock()
+
+_disable_beforeunload_prompt()
 
 
 async def main():


### PR DESCRIPTION
## Summary
- detect the js runtime and remove the beforeunload handler so the web demo no longer warns about unsaved changes

## Testing
- python -m unittest discover -s tests -p "test_*.py"
- python -m compileall simulation

------
https://chatgpt.com/codex/tasks/task_e_68d7adbfb08083278dd178f3e04f4f52