### PR TITLE
Fix static asset paths for GitHub Pages

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/png" href="./favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
     <title>Phaser - Template</title>
 </head>
 

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+});


### PR DESCRIPTION
## Summary
- update the favicon and stylesheet links to use relative URLs so GitHub Pages can resolve them inside the repository path
- add a Vite configuration that emits relative asset paths during production builds to keep the deployment portable

## Testing
- npm run build
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d7b8e99b008327ad9b71d8ee430db3