### PR TITLE
Add dataclasses_json integration and websocket API router

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package exposing the shared FastAPI router."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/backend/api/router.py
+++ b/backend/api/router.py
@@ -1,0 +1,38 @@
+"""FastAPI router with websocket support for the Compotastic backend."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health_check() -> dict[str, str]:
+    """Return a simple response to verify the service is reachable."""
+
+    logger.debug("Health check requested")
+    return {"status": "ok"}
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    """Accept websocket connections and echo received messages."""
+
+    await websocket.accept()
+    logger.info("Websocket connection accepted from %s", websocket.client)
+    try:
+        while True:
+            message = await websocket.receive_text()
+            logger.debug("Websocket message received: %s", message)
+            await websocket.send_text(message)
+    except WebSocketDisconnect:
+        logger.info("Websocket client disconnected: %s", websocket.client)
+    except Exception as exc:  # pragma: no cover - defensive logging for unexpected errors
+        logger.exception("Unexpected websocket error: %s", exc)
+        await websocket.close(code=1011)
+        raise

--- a/backend/simulation/logic/__init__.py
+++ b/backend/simulation/logic/__init__.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from dataclasses import replace
 from typing import Iterable
 
+from dataclasses_json import dataclass_json
 
+
+@dataclass_json
 @dataclass(frozen=True)
 class LogicProbe:
     """Lightweight object used to verify simulation logic imports."""
@@ -19,6 +22,7 @@ class LogicProbe:
         return True
 
 
+@dataclass_json
 @dataclass(frozen=True)
 class GridLocation:
     """Simple integer based coordinate used to place nodes on a 2D grid."""
@@ -38,6 +42,7 @@ class GridLocation:
         return GridLocation(self.x + dx, self.y + dy)
 
 
+@dataclass_json
 @dataclass(frozen=True)
 class MeshtasticNode:
     """Representation of a Meshtastic node used in the simulation grid."""


### PR DESCRIPTION
## Summary
- decorate the simulation dataclasses with dataclasses_json to enable serialization helpers
- add a FastAPI router package with a health check endpoint and websocket echo handler for frontend integration

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d7c4786d408327afb1fe5ef6c06d05