### PR TITLE
feat(ui): defer coin spawn until websocket connects

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 # Simulation UI
 
-This web based UI uses Phaser.js <https://github.com/phaserjs/phaser> v3.90.0 to display the simulation logic which is synchronized with the backend via a websockets connection.
+This web based UI uses Phaser.js <https://github.com/phaserjs/phaser> v3.90.0 to display the simulation logic which is synchronized with the backend via a websockets connection. By default the client connects to `ws://localhost:8000`, but you can override this during build time by setting the `VITE_WS_URL` environment variable.
 
 ## Instructions
 

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,0 +1,13 @@
+const DEFAULT_WS_URL = 'ws://localhost:8000';
+
+export function getWebSocketUrl ()
+{
+    const configuredUrl = import.meta.env.VITE_WS_URL;
+
+    if (configuredUrl && configuredUrl.trim().length > 0)
+    {
+        return configuredUrl;
+    }
+
+    return DEFAULT_WS_URL;
+}


### PR DESCRIPTION
## Summary
- add a configuration helper so the websocket URL can be overridden at build time
- connect the Phaser clicker scene to the websocket and delay spawning coins until the connection opens
- document how to configure the websocket endpoint for the UI build

## Testing
- npm ci
- npm run build
- python -m unittest discover -s tests -p "test_*.py" *(fails: ModuleNotFoundError: No module named 'dataclasses_json')*

------
https://chatgpt.com/codex/tasks/task_e_68d7c5e902248327825ef1e79c1298bb