### PR TITLE
Add websocket connection status overlay

### DIFF
--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -4,6 +4,7 @@ import { Game } from 'phaser';
 import { GameOver } from './scenes/GameOver';
 import { MainMenu } from './scenes/MainMenu';
 import { Preloader } from './scenes/Preloader';
+import { ConnectionStatusOverlay } from './scenes/ConnectionStatusOverlay';
 
 //  Find out more information about the Game Config at: https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
 const config = {
@@ -27,7 +28,8 @@ const config = {
         Preloader,
         MainMenu,
         ClickerGame,
-        GameOver
+        GameOver,
+        ConnectionStatusOverlay
     ]
 };
 

--- a/ui/src/network/WebSocketManager.js
+++ b/ui/src/network/WebSocketManager.js
@@ -1,0 +1,153 @@
+import { getWebSocketUrl } from '../config';
+
+const RETRY_DELAY_MS = 3000;
+
+class WebSocketManager
+{
+    constructor (game)
+    {
+        this.game = game;
+        this.events = game.events;
+        this.registry = game.registry;
+        this.socket = null;
+        this.retryHandle = null;
+        this.isDestroyed = false;
+
+        this.handleOpen = this.handleOpen.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.handleError = this.handleError.bind(this);
+        this.tryConnect = this.tryConnect.bind(this);
+
+        if (!this.registry.has('wsConnected'))
+        {
+            this.registry.set('wsConnected', false);
+        }
+
+        this.tryConnect();
+    }
+
+    tryConnect ()
+    {
+        if (this.isDestroyed || this.socket)
+        {
+            return;
+        }
+
+        let socket;
+
+        try
+        {
+            socket = new WebSocket(getWebSocketUrl());
+        }
+        catch (error)
+        {
+            this.scheduleRetry();
+
+            return;
+        }
+
+        this.socket = socket;
+        socket.addEventListener('open', this.handleOpen);
+        socket.addEventListener('close', this.handleClose);
+        socket.addEventListener('error', this.handleError);
+    }
+
+    handleOpen ()
+    {
+        if (this.isDestroyed)
+        {
+            return;
+        }
+
+        this.clearRetry();
+        this.registry.set('wsConnected', true);
+        this.events.emit('ws-connected');
+    }
+
+    handleClose ()
+    {
+        if (this.isDestroyed)
+        {
+            return;
+        }
+
+        this.registry.set('wsConnected', false);
+        this.events.emit('ws-disconnected');
+
+        this.cleanupSocket();
+        this.scheduleRetry();
+    }
+
+    handleError ()
+    {
+        if (this.socket)
+        {
+            this.socket.close();
+        }
+    }
+
+    cleanupSocket ()
+    {
+        if (!this.socket)
+        {
+            return;
+        }
+
+        this.socket.removeEventListener('open', this.handleOpen);
+        this.socket.removeEventListener('close', this.handleClose);
+        this.socket.removeEventListener('error', this.handleError);
+        this.socket = null;
+    }
+
+    scheduleRetry ()
+    {
+        if (this.isDestroyed || this.retryHandle)
+        {
+            return;
+        }
+
+        this.retryHandle = globalThis.setTimeout(() =>
+        {
+            this.retryHandle = null;
+            this.tryConnect();
+        }, RETRY_DELAY_MS);
+    }
+
+    clearRetry ()
+    {
+        if (!this.retryHandle)
+        {
+            return;
+        }
+
+        globalThis.clearTimeout(this.retryHandle);
+        this.retryHandle = null;
+    }
+
+    destroy ()
+    {
+        this.isDestroyed = true;
+        this.clearRetry();
+
+        if (this.socket)
+        {
+            this.socket.removeEventListener('open', this.handleOpen);
+            this.socket.removeEventListener('close', this.handleClose);
+            this.socket.removeEventListener('error', this.handleError);
+            this.socket.close();
+            this.socket = null;
+        }
+    }
+}
+
+let instance = null;
+
+export function ensureWebSocketManager (game)
+{
+    if (!instance)
+    {
+        instance = new WebSocketManager(game);
+    }
+
+    return instance;
+}

--- a/ui/src/scenes/Boot.js
+++ b/ui/src/scenes/Boot.js
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import { ensureWebSocketManager } from '../network/WebSocketManager';
 
 export class Boot extends Scene
 {
@@ -19,6 +20,13 @@ export class Boot extends Scene
     {
         //  A global value to store the highscore in
         this.registry.set('highscore', 0);
+
+        ensureWebSocketManager(this.game);
+
+        if (!this.scene.isActive('ConnectionStatusOverlay'))
+        {
+            this.scene.launch('ConnectionStatusOverlay');
+        }
 
         // this.scene.start('Preloader');
 

--- a/ui/src/scenes/ConnectionStatusOverlay.js
+++ b/ui/src/scenes/ConnectionStatusOverlay.js
@@ -1,0 +1,70 @@
+import { Scene } from 'phaser';
+
+export class ConnectionStatusOverlay extends Scene
+{
+    constructor ()
+    {
+        super('ConnectionStatusOverlay');
+    }
+
+    create ()
+    {
+        const style = {
+            fontFamily: 'Arial',
+            fontSize: '18px',
+            color: '#00ff00',
+            backgroundColor: 'rgba(0, 0, 0, 0.4)',
+            padding: { x: 8, y: 4 }
+        };
+
+        this.statusText = this.add.text(this.scale.width - 16, this.scale.height - 16, 'connected', style)
+            .setOrigin(1, 1)
+            .setScrollFactor(0)
+            .setDepth(1000)
+            .setVisible(false);
+
+        this.scale.on('resize', this.handleResize, this);
+        this.events.once('shutdown', this.handleShutdown, this);
+        this.events.once('destroy', this.handleShutdown, this);
+
+        this.game.events.on('ws-connected', this.handleConnected, this);
+        this.game.events.on('ws-disconnected', this.handleDisconnected, this);
+
+        if (this.registry.get('wsConnected'))
+        {
+            this.handleConnected();
+        }
+    }
+
+    handleResize (gameSize)
+    {
+        this.statusText.setPosition(gameSize.width - 16, gameSize.height - 16);
+    }
+
+    handleConnected ()
+    {
+        if (!this.statusText)
+        {
+            return;
+        }
+
+        this.statusText.setVisible(true);
+    }
+
+    handleDisconnected ()
+    {
+        if (!this.statusText)
+        {
+            return;
+        }
+
+        this.statusText.setVisible(false);
+    }
+
+    handleShutdown ()
+    {
+        this.scale.off('resize', this.handleResize, this);
+        this.game.events.off('ws-connected', this.handleConnected, this);
+        this.game.events.off('ws-disconnected', this.handleDisconnected, this);
+    }
+}


### PR DESCRIPTION
## Summary
- add a websocket manager that repeatedly attempts to connect using the configured URL
- display a connection status overlay scene that shows "connected" once a socket opens
- initialize the manager and overlay from the Boot scene and register the overlay with the game

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7cdc2e1188327889c1fbe2bd07059