### PR TITLE
Ensure simulation viewport is square and scale cats to tiles

### DIFF
--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -7,10 +7,12 @@ import { Preloader } from './scenes/Preloader';
 import { ConnectionStatusOverlay } from './scenes/ConnectionStatusOverlay';
 
 //  Find out more information about the Game Config at: https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
+const computeSquareSize = () => Math.min(window.innerHeight, window.innerWidth);
+
 const config = {
     type: Phaser.AUTO,
-    width: 1024,
-    height: 768,
+    width: computeSquareSize(),
+    height: computeSquareSize(),
     parent: 'game-container',
     backgroundColor: '#028af8',
     scale: {
@@ -33,4 +35,14 @@ const config = {
     ]
 };
 
-export default new Game(config);
+const game = new Game(config);
+
+const resizeGame = () => {
+    const size = computeSquareSize();
+
+    game.scale.setGameSize(size, size);
+};
+
+window.addEventListener('resize', resizeGame);
+
+export default game;

--- a/ui/src/scenes/Simulation.js
+++ b/ui/src/scenes/Simulation.js
@@ -3,6 +3,7 @@ import Phaser, { Scene } from 'phaser';
 const DEFAULT_CAT_COUNT = 10;
 const CAT_ASCII = '^.^';
 const CAT_FONT_STYLE = { fontFamily: 'Courier', fontSize: 32, color: '#e27272ff' };
+const CAT_TILE_PADDING_RATIO = 0.2;
 const CAT_SPEED_RANGE = { min: 40, max: 140 };
 const LOOK_INTERVAL_RANGE = { min: 800, max: 2200 };
 const GRID_TILE_COUNT = { width: 250, height: 250 };
@@ -39,6 +40,7 @@ class Cat {
         this.speed = Phaser.Math.Between(CAT_SPEED_RANGE.min, CAT_SPEED_RANGE.max);
         this.text = scene.add.text(0, 0, CAT_ASCII, CAT_FONT_STYLE);
         this.text.setOrigin(0.5, 0.5);
+        this.scaleToTile();
 
         this.tileX = tileX;
         this.tileY = tileY;
@@ -65,6 +67,24 @@ class Cat {
         this.text.setPosition(position.x, position.y);
         this.targetPixelX = position.x;
         this.targetPixelY = position.y;
+    }
+
+    scaleToTile() {
+        const horizontalPadding = GRID_TILE_SIZE * CAT_TILE_PADDING_RATIO;
+        const verticalPadding = GRID_TILE_SIZE * CAT_TILE_PADDING_RATIO;
+        const maxWidth = GRID_TILE_SIZE - horizontalPadding;
+        const maxHeight = GRID_TILE_SIZE - verticalPadding;
+        const textWidth = this.text.width;
+        const textHeight = this.text.height;
+
+        if (textWidth === 0 || textHeight === 0) {
+            this.text.setScale(1);
+            return;
+        }
+
+        const scale = Math.min(maxWidth / textWidth, maxHeight / textHeight);
+
+        this.text.setScale(scale);
     }
 
     lookAround(time) {


### PR DESCRIPTION
## Summary
- size the Phaser game viewport using a square dimension derived from the current window to keep grid tiles square on any screen
- resize the game dynamically on browser resizes so the square viewport is preserved
- scale ASCII cat sprites so that each cat fits neatly inside a single grid tile with padding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d68b293883278cf9838259e512d5