### PR TITLE
Add integer-based Q-learning utilities

### DIFF
--- a/backend/simulation/logic/__init__.py
+++ b/backend/simulation/logic/__init__.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import replace
+from enum import IntEnum
+from typing import Callable
+from typing import Dict
 from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+
+import random
 
 from dataclasses_json import dataclass_json
 
@@ -40,6 +49,106 @@ class GridLocation:
         if not isinstance(dx, int) or not isinstance(dy, int):
             raise TypeError("GridLocation translation requires integer deltas")
         return GridLocation(self.x + dx, self.y + dy)
+
+
+class Action(IntEnum):
+    """Integer encoded actions available to agents exploring the grid."""
+
+    MOVE_FORWARD = 0
+    MOVE_BACKWARD = 1
+    MOVE_LEFT = 2
+    MOVE_RIGHT = 3
+    DO_WORK = 4
+    STOP = 5
+    CALL_FOR_HELP = 6
+
+
+_ACTION_TO_VECTOR: Dict[Action, Tuple[int, int]] = {
+    Action.MOVE_FORWARD: (0, -1),
+    Action.MOVE_BACKWARD: (0, 1),
+    Action.MOVE_LEFT: (-1, 0),
+    Action.MOVE_RIGHT: (1, 0),
+}
+
+
+def _default_logger(message: str) -> None:
+    """No-op logger used when a caller does not provide a callback."""
+
+    # Intentionally left blank – satisfies the logging callback contract.
+    return None
+
+
+@dataclass(frozen=True)
+class Surroundings:
+    """Represents which integer encoded actions are currently available."""
+
+    can_move_forward: bool
+    can_move_backward: bool
+    can_move_left: bool
+    can_move_right: bool
+    can_do_work: bool
+    can_stop: bool
+    can_call_for_help: bool
+
+    def __post_init__(self) -> None:
+        for field_name, value in self.__dict__.items():
+            if not isinstance(value, bool):
+                raise TypeError(f"{field_name} must be a boolean")
+
+    def action_mask(self) -> int:
+        """Return an integer mask encoding the available actions."""
+
+        flags = (
+            self.can_move_forward,
+            self.can_move_backward,
+            self.can_move_left,
+            self.can_move_right,
+            self.can_do_work,
+            self.can_stop,
+            self.can_call_for_help,
+        )
+        mask = 0
+        for index, is_allowed in enumerate(flags):
+            if is_allowed:
+                mask |= 1 << index
+        return mask
+
+    def available_actions(self) -> List[int]:
+        """Return the integer identifiers for actions that can be taken."""
+
+        actions = []
+        if self.can_move_forward:
+            actions.append(Action.MOVE_FORWARD)
+        if self.can_move_backward:
+            actions.append(Action.MOVE_BACKWARD)
+        if self.can_move_left:
+            actions.append(Action.MOVE_LEFT)
+        if self.can_move_right:
+            actions.append(Action.MOVE_RIGHT)
+        if self.can_do_work:
+            actions.append(Action.DO_WORK)
+        if self.can_stop:
+            actions.append(Action.STOP)
+        if self.can_call_for_help:
+            actions.append(Action.CALL_FOR_HELP)
+        return [int(action) for action in actions]
+
+
+@dataclass(frozen=True)
+class NodeState:
+    """Encapsulates the location and surroundings for Q-learning."""
+
+    location: GridLocation
+    surroundings: Surroundings
+
+    def encode(self, grid_width: int) -> int:
+        """Encode the state as an integer for table based learning."""
+
+        if not isinstance(grid_width, int) or grid_width <= 0:
+            raise ValueError("grid_width must be a positive integer")
+        position_index = self.location.y * grid_width + self.location.x
+        surroundings_mask = self.surroundings.action_mask()
+        return position_index * (1 << len(Action)) + surroundings_mask
 
 
 @dataclass_json
@@ -112,9 +221,195 @@ def validate_unique_identifiers(nodes: Iterable[MeshtasticNode]) -> None:
         seen.add(node.identifier)
 
 
+class GridWorldEnvironment:
+    """Simple integer-based grid used to train reinforcement learning agents."""
+
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        rewards: Optional[Dict[Tuple[int, int], int]] = None,
+        log_callback: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        if not isinstance(width, int) or width <= 0:
+            raise ValueError("width must be a positive integer")
+        if not isinstance(height, int) or height <= 0:
+            raise ValueError("height must be a positive integer")
+        self.width = width
+        self.height = height
+        self._rewards = {
+            (int(x), int(y)): int(value)
+            for (x, y), value in (rewards or {}).items()
+        }
+        self._log = log_callback or _default_logger
+
+    def _within_bounds(self, location: GridLocation) -> bool:
+        return 0 <= location.x < self.width and 0 <= location.y < self.height
+
+    def surroundings_for(self, location: GridLocation) -> Surroundings:
+        """Return the available actions for a node at the supplied location."""
+
+        if not self._within_bounds(location):
+            raise ValueError("location must be within the grid bounds")
+        return Surroundings(
+            can_move_forward=location.y > 0,
+            can_move_backward=location.y < self.height - 1,
+            can_move_left=location.x > 0,
+            can_move_right=location.x < self.width - 1,
+            can_do_work=True,
+            can_stop=True,
+            can_call_for_help=True,
+        )
+
+    def encode_state(self, location: GridLocation) -> int:
+        """Encode the state represented by a location and its surroundings."""
+
+        surroundings = self.surroundings_for(location)
+        return NodeState(location, surroundings).encode(self.width)
+
+    def reward_at(self, location: GridLocation) -> int:
+        """Return the reward associated with the given grid location."""
+
+        return self._rewards.get((location.x, location.y), 0)
+
+    def step(
+        self,
+        node: MeshtasticNode,
+        action: int,
+    ) -> Tuple[int, MeshtasticNode, int, bool]:
+        """Apply an integer encoded action to the node and return the outcome."""
+
+        if not isinstance(action, int):
+            raise TypeError("action must be provided as an integer")
+        try:
+            resolved_action = Action(action)
+        except ValueError as exc:
+            raise ValueError(f"Unknown action: {action}") from exc
+
+        surroundings = self.surroundings_for(node.location)
+        available_actions = surroundings.available_actions()
+        if action not in available_actions:
+            self._log(
+                f"Action {resolved_action.name} is unavailable at location {node.location}"
+            )
+            return self.encode_state(node.location), node, -1, False
+
+        if resolved_action in _ACTION_TO_VECTOR:
+            dx, dy = _ACTION_TO_VECTOR[resolved_action]
+            new_location = node.location.translated(dx, dy)
+            reward = self.reward_at(new_location)
+            updated_node = node.with_location(new_location)
+            return self.encode_state(new_location), updated_node, reward, False
+
+        if resolved_action is Action.DO_WORK:
+            reward = self.reward_at(node.location)
+            return self.encode_state(node.location), node, reward, False
+
+        if resolved_action is Action.STOP:
+            return self.encode_state(node.location), node, 0, True
+
+        if resolved_action is Action.CALL_FOR_HELP:
+            self._log(
+                f"Node {node.identifier} requested assistance at {node.location}"
+            )
+            return self.encode_state(node.location), node, -1, False
+
+        return self.encode_state(node.location), node, 0, False
+
+
+class QLearningAgent:
+    """Integer based Q-learning implementation for grid exploration."""
+
+    def __init__(
+        self,
+        learning_rate: float = 0.1,
+        discount_factor: float = 0.9,
+        exploration_rate: float = 0.1,
+        log_callback: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        if not 0 < learning_rate <= 1:
+            raise ValueError("learning_rate must be within the range (0, 1]")
+        if not 0 <= discount_factor <= 1:
+            raise ValueError("discount_factor must be within the range [0, 1]")
+        if not 0 <= exploration_rate <= 1:
+            raise ValueError("exploration_rate must be within the range [0, 1]")
+        self.learning_rate = float(learning_rate)
+        self.discount_factor = float(discount_factor)
+        self.exploration_rate = float(exploration_rate)
+        self._log = log_callback or _default_logger
+        self._q_table: Dict[int, Dict[int, float]] = {}
+
+    def get_q_value(self, state: int, action: int) -> float:
+        """Return the Q-value for the given integer state-action pair."""
+
+        return self._q_table.get(state, {}).get(action, 0.0)
+
+    def _set_q_value(self, state: int, action: int, value: float) -> None:
+        state_values = self._q_table.setdefault(state, {})
+        state_values[action] = float(value)
+
+    def choose_action(
+        self,
+        state: int,
+        available_actions: Sequence[int],
+        exploration_rate: Optional[float] = None,
+    ) -> int:
+        """Select an action using an epsilon-greedy policy."""
+
+        if not available_actions:
+            raise ValueError("available_actions must not be empty")
+        epsilon = self.exploration_rate if exploration_rate is None else float(exploration_rate)
+        if epsilon < 0 or epsilon > 1:
+            raise ValueError("exploration_rate must be within the range [0, 1]")
+        if random.random() < epsilon:
+            return int(random.choice(list(available_actions)))
+        best_action = int(available_actions[0])
+        best_value = self.get_q_value(state, best_action)
+        for candidate in available_actions[1:]:
+            candidate_value = self.get_q_value(state, int(candidate))
+            if candidate_value > best_value:
+                best_value = candidate_value
+                best_action = int(candidate)
+        return best_action
+
+    def learn(
+        self,
+        state: int,
+        action: int,
+        reward: float,
+        next_state: int,
+        next_available_actions: Optional[Sequence[int]] = None,
+    ) -> None:
+        """Update the Q-table based on an observed transition."""
+
+        current_q = self.get_q_value(state, action)
+        next_values = [
+            self.get_q_value(next_state, int(next_action))
+            for next_action in next_available_actions or []
+        ]
+        best_next_q = max(next_values) if next_values else 0.0
+        updated_q = (1 - self.learning_rate) * current_q + self.learning_rate * (
+            reward + self.discount_factor * best_next_q
+        )
+        self._set_q_value(state, action, updated_q)
+
+    def policy(self, state: int) -> Optional[int]:
+        """Return the greedy action for the supplied state if it exists."""
+
+        state_actions = self._q_table.get(state)
+        if not state_actions:
+            return None
+        return max(state_actions, key=state_actions.get)
+
+
 __all__ = [
     "LogicProbe",
     "GridLocation",
     "MeshtasticNode",
     "validate_unique_identifiers",
+    "Action",
+    "Surroundings",
+    "NodeState",
+    "GridWorldEnvironment",
+    "QLearningAgent",
 ]

--- a/backend/tests/test_q_learning.py
+++ b/backend/tests/test_q_learning.py
@@ -1,0 +1,122 @@
+"""Unit tests for the integer based Q-learning utilities."""
+
+from __future__ import annotations
+
+import unittest
+
+from simulation.logic import Action
+from simulation.logic import GridLocation
+from simulation.logic import GridWorldEnvironment
+from simulation.logic import MeshtasticNode
+from simulation.logic import NodeState
+from simulation.logic import QLearningAgent
+from simulation.logic import Surroundings
+
+
+class SurroundingsTests(unittest.TestCase):
+    """Verify that surroundings encode and expose actions correctly."""
+
+    def test_action_mask_and_available_actions(self) -> None:
+        surroundings = Surroundings(
+            can_move_forward=True,
+            can_move_backward=False,
+            can_move_left=True,
+            can_move_right=False,
+            can_do_work=True,
+            can_stop=True,
+            can_call_for_help=True,
+        )
+        self.assertEqual(surroundings.action_mask(), 117)
+        self.assertEqual(
+            set(surroundings.available_actions()),
+            {
+                int(Action.MOVE_FORWARD),
+                int(Action.MOVE_LEFT),
+                int(Action.DO_WORK),
+                int(Action.STOP),
+                int(Action.CALL_FOR_HELP),
+            },
+        )
+
+
+class NodeStateTests(unittest.TestCase):
+    """Ensure node states produce deterministic integer encodings."""
+
+    def test_state_encoding_uses_position_and_surroundings(self) -> None:
+        surroundings = Surroundings(
+            can_move_forward=True,
+            can_move_backward=True,
+            can_move_left=True,
+            can_move_right=True,
+            can_do_work=True,
+            can_stop=True,
+            can_call_for_help=False,
+        )
+        state = NodeState(GridLocation(1, 1), surroundings)
+        # Expected value: ((1 * 5) + 1) * 128 + mask(=63)
+        self.assertEqual(state.encode(5), 768 + 63)
+
+
+class GridWorldEnvironmentTests(unittest.TestCase):
+    """Validate grid transitions and reward propagation."""
+
+    def test_step_moves_node_and_returns_reward(self) -> None:
+        env = GridWorldEnvironment(width=3, height=3, rewards={(1, 0): 5, (1, 1): 2})
+        node = MeshtasticNode(
+            identifier="node-1",
+            battery_level=75.0,
+            compute_efficiency_flops_per_milliamp=10.0,
+            location=GridLocation(1, 1),
+        )
+        state_id = env.encode_state(node.location)
+        next_state, updated_node, reward, done = env.step(node, int(Action.MOVE_FORWARD))
+        self.assertFalse(done)
+        self.assertEqual(updated_node.location, GridLocation(1, 0))
+        self.assertEqual(reward, 5)
+        self.assertNotEqual(state_id, next_state)
+
+    def test_unavailable_action_penalizes_agent(self) -> None:
+        env = GridWorldEnvironment(width=2, height=2)
+        node = MeshtasticNode(
+            identifier="node-edge",
+            battery_level=60.0,
+            compute_efficiency_flops_per_milliamp=8.0,
+            location=GridLocation(0, 0),
+        )
+        state_id, updated_node, reward, done = env.step(node, int(Action.MOVE_FORWARD))
+        self.assertEqual(state_id, env.encode_state(node.location))
+        self.assertEqual(updated_node.location, node.location)
+        self.assertEqual(reward, -1)
+        self.assertFalse(done)
+
+
+class QLearningAgentTests(unittest.TestCase):
+    """Confirm the Q-learning agent updates values correctly."""
+
+    def test_learn_updates_q_values(self) -> None:
+        agent = QLearningAgent(learning_rate=0.5, discount_factor=0.5, exploration_rate=0.0)
+        state = 10
+        next_state = 20
+        agent.learn(state, int(Action.DO_WORK), reward=5, next_state=next_state, next_available_actions=[])
+        self.assertAlmostEqual(agent.get_q_value(state, int(Action.DO_WORK)), 2.5)
+        self.assertEqual(agent.policy(state), int(Action.DO_WORK))
+
+    def test_choose_action_prefers_best_q_value(self) -> None:
+        agent = QLearningAgent(learning_rate=0.5, discount_factor=0.9, exploration_rate=0.0)
+        state = 42
+        agent.learn(state, int(Action.MOVE_FORWARD), reward=1, next_state=state, next_available_actions=[])
+        agent.learn(state, int(Action.DO_WORK), reward=3, next_state=state, next_available_actions=[])
+        choice = agent.choose_action(
+            state,
+            [
+                int(Action.MOVE_FORWARD),
+                int(Action.DO_WORK),
+                int(Action.STOP),
+            ],
+            exploration_rate=0.0,
+        )
+        self.assertEqual(choice, int(Action.DO_WORK))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add integer-encoded action, state, environment, and agent helpers for Q-learning
- wire optional logging callbacks into the grid environment and learning agent
- add unit tests covering surroundings encoding, state encoding, environment transitions, and Q-value updates

## Testing
- .venv/bin/python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d7d747bc64832792ac094c6d575b33