### PR TITLE
Add collapsible project info panel to Phaser index

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -10,8 +10,38 @@
 
 <body>
     <div id="app">
+        <aside id="info-panel" class="info-panel" aria-label="Project information">
+            <div class="info-header">
+                <h1>Project Guide 🚀</h1>
+                <button id="info-toggle" type="button" aria-controls="panel-content" aria-expanded="true">
+                    Hide guide 🙈
+                </button>
+            </div>
+            <div id="panel-content" class="info-content">
+                <p>Welcome to the Phaser-powered playground! 🎮 This demo boots up a lightweight scene so you can explore how our Unity-integrated web view talks to Phaser.</p>
+                <p>Here is what happens behind the scenes:</p>
+                <ul>
+                    <li>🧩 The Vite entry point loads Phaser and our custom scenes.</li>
+                    <li>⚙️ Configuration files wire up asset loading and input handling.</li>
+                    <li>🔄 Unity uses this build as an embedded web surface for rapid iteration.</li>
+                </ul>
+                <p>Need a refresher? Click the toggle again to bring this helper back. Happy tinkering! ✨</p>
+            </div>
+        </aside>
         <div id="game-container"></div>
     </div>
     <script type="module" src="src/main.js"></script>
+    <script>
+        const infoPanel = document.getElementById('info-panel');
+        const infoToggle = document.getElementById('info-toggle');
+
+        if (infoPanel && infoToggle) {
+            infoToggle.addEventListener('click', () => {
+                const collapsed = infoPanel.classList.toggle('collapsed');
+                infoToggle.setAttribute('aria-expanded', (!collapsed).toString());
+                infoToggle.textContent = collapsed ? 'Show guide 📘' : 'Hide guide 🙈';
+            });
+        }
+    </script>
 </body>
 </html>

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -10,6 +10,83 @@ body {
     height: 100vh;
     overflow: hidden;
     display: flex;
+    justify-content: flex-start;
+    align-items: stretch;
+    gap: 1rem;
+    box-sizing: border-box;
+    padding: 1rem;
+}
+
+.info-panel {
+    width: 320px;
+    background: rgba(22, 22, 22, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow: hidden;
+    transition: width 0.25s ease, padding 0.25s ease;
+}
+
+.info-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.info-header h1 {
+    margin: 0;
+    font-size: 1.4rem;
+}
+
+#info-toggle {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: inherit;
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background 0.2s ease;
+}
+
+#info-toggle:hover,
+#info-toggle:focus {
+    background: rgba(255, 255, 255, 0.16);
+    outline: none;
+}
+
+.info-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.info-content ul {
+    margin: 0;
+    padding-left: 1.2rem;
+}
+
+.info-panel.collapsed {
+    width: auto;
+    padding: 0.75rem;
+    align-items: center;
+}
+
+.info-panel.collapsed .info-header h1,
+.info-panel.collapsed .info-content {
+    display: none;
+}
+
+#game-container {
+    flex: 1;
+    display: flex;
     justify-content: center;
     align-items: center;
 }


### PR DESCRIPTION
## Summary
- add a left-aligned project guide panel to the Phaser HTML shell
- describe the project flow with emoji-rich messaging and collapsible toggle behavior
- update layout and styling so the game canvas and info panel share space cleanly

## Testing
- npm run build
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d7e9857584832791d7f4c530165224