### PR TITLE
Document protobuf generation workflow

### DIFF
--- a/mesh_connector/README.md
+++ b/mesh_connector/README.md
@@ -1,3 +1,33 @@
 # Meshtastic Connector
 
 This is the actual connector and executor that can connect to the different Meshtastic nodes and send across a message in compute format including updates for the Q-learning state that each node reads from. For the hackathon the Q-learning implementation is in the simulation only and the attributes are faked for each node on the mesh.
+
+## Protocol buffers
+
+The connector publishes application data in the Meshtastic `MeshPacket.data` field using the [`protos/mesh_connector.proto`](protos/mesh_connector.proto) definition. The top-level `AddressableMeshData` wrapper adds compact addressing and sequencing metadata on top of Meshtastic's routing so each Compotastic node can quickly determine whether the payload is relevant.
+
+### Generating Python bindings
+
+Run the protocol compiler whenever the `.proto` schema changes so that the mesh connector keeps its generated classes in sync. From the repository root, execute:
+
+```bash
+python -m grpc_tools.protoc \
+  --proto_path=mesh_connector/protos \
+  --proto_path=$(python -c "import meshtastic, pathlib; print(pathlib.Path(meshtastic.__file__).resolve().parent)")/protos \
+  --python_out=mesh_connector/protos \
+  mesh_connector/protos/mesh_connector.proto
+```
+
+This command compiles the Compotastic schema while including the Meshtastic package's distributed `.proto` files so imports like `meshtastic/mesh.proto` resolve correctly. The generated Python module will appear alongside the source definition inside `mesh_connector/protos`.
+
+### State updates
+
+`StateUpdate` is the first payload carried within the wrapper. It mirrors the tuple returned by `GridWorldEnvironment.step` in `backend/simulation/logic` while packing the location, action, completion flag, and reward into a single 32-bit field:
+
+- Bits `00-09`: grid X coordinate (0-1023)
+- Bits `10-19`: grid Y coordinate (0-1023)
+- Bits `20-22`: action identifier from `simulation.logic.Action`
+- Bit `23`: `done` flag from the environment step result
+- Bits `24-31`: signed reward encoded as two's complement (-128..127)
+
+The original and resulting encoded states are also included so that downstream Q-learning agents can reconstruct table updates without relying on implicit context from the transmission.

--- a/mesh_connector/protos/__init__.py
+++ b/mesh_connector/protos/__init__.py
@@ -1,0 +1,12 @@
+"""Protocol buffer definitions for the mesh connector payloads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Provide runtime access to the raw .proto file so tooling can locate and compile
+# it without needing hard coded paths within the repository tree.
+PROTO_ROOT = Path(__file__).resolve().parent
+MESH_CONNECTOR_PROTO = PROTO_ROOT / "mesh_connector.proto"
+
+__all__ = ["PROTO_ROOT", "MESH_CONNECTOR_PROTO"]

--- a/mesh_connector/protos/mesh_connector.proto
+++ b/mesh_connector/protos/mesh_connector.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package compotastic.mesh;
+
+option csharp_namespace = "Compotastic.Mesh";
+option go_package = "github.com/compotastic/protos/mesh";
+option java_multiple_files = true;
+option java_package = "ai.compotastic.mesh";
+option objc_class_prefix = "CMX";
+option swift_prefix = "CMX";
+
+// The Meshtastic python package distributes mesh.proto alongside its generated
+// classes. Importing it here keeps the compiler aware of MeshPacket and other
+// core types when we extend the data payload with application specific frames.
+import "meshtastic/mesh.proto";
+
+// AddressableMeshData wraps the Meshtastic MeshPacket data field so that the
+// library can identify which cooperating node should process an application
+// level payload.
+message AddressableMeshData {
+  // Protocol version for this wrapper so receivers can evolve independently
+  // from the underlying Meshtastic firmware version.
+  uint32 protocol_version = 1;
+
+  // Application identifier differentiating Compotastic payloads from other
+  // custom data consumers. The value is opaque to Meshtastic itself but allows
+  // upstream routing logic to select the correct decoder.
+  uint32 application_id = 2;
+
+  // Compact 24-bit addresses for routing across the mesh. Values above
+  // 0x00FF_FFFF are reserved for future extensions. A destination of zero
+  // indicates broadcast delivery to any interested node.
+  uint32 source_address = 3;
+  uint32 destination_address = 4;
+
+  // Sequence number used for de-duplication when retransmissions occur.
+  uint32 sequence_id = 5;
+
+  oneof payload {
+    StateUpdate state_update = 16;
+  }
+}
+
+// StateUpdate represents a single reinforcement learning transition emitted by
+// the simulation code in backend/simulation/logic. The structure mirrors the
+// tuple returned by GridWorldEnvironment.step while packing the grid location,
+// action, completion flag, and reward into a single 32-bit field to minimise
+// airtime.
+message StateUpdate {
+  // Packed layout (least significant bit first):
+  //   bits 00-09 -> X coordinate (0-1023)
+  //   bits 10-19 -> Y coordinate (0-1023)
+  //   bits 20-22 -> Action value (simulation.logic.Action enum)
+  //   bit  23    -> Done flag from GridWorldEnvironment.step
+  //   bits 24-31 -> Signed reward in two's complement (-128..127)
+  fixed32 packed_transition = 1;
+
+  // Encoded state identifiers use the NodeState.encode() helper from the
+  // simulation. These values allow learners to reconstruct Q-table updates.
+  uint32 prior_state_id = 2;
+  uint32 next_state_id = 3;
+}


### PR DESCRIPTION
## Summary
- add documentation for regenerating Python bindings for the mesh connector protobufs
- include the Meshtastic include path in the protoc example so imports resolve correctly

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d7fd5fdf048327b8a3f3ed96b51e30