### PR TITLE
Add ASCII border around simulation grid

### DIFF
--- a/backend/tests/test_q_learning.py
+++ b/backend/tests/test_q_learning.py
@@ -61,27 +61,27 @@ class GridWorldEnvironmentTests(unittest.TestCase):
     """Validate grid transitions and reward propagation."""
 
     def test_step_moves_node_and_returns_reward(self) -> None:
-        env = GridWorldEnvironment(width=3, height=3, rewards={(1, 0): 5, (1, 1): 2})
+        env = GridWorldEnvironment(width=5, height=5, rewards={(2, 1): 5, (2, 2): 2})
         node = MeshtasticNode(
             identifier="node-1",
             battery_level=75.0,
             compute_efficiency_flops_per_milliamp=10.0,
-            location=GridLocation(1, 1),
+            location=GridLocation(2, 2),
         )
         state_id = env.encode_state(node.location)
         next_state, updated_node, reward, done = env.step(node, int(Action.MOVE_FORWARD))
         self.assertFalse(done)
-        self.assertEqual(updated_node.location, GridLocation(1, 0))
+        self.assertEqual(updated_node.location, GridLocation(2, 1))
         self.assertEqual(reward, 5)
         self.assertNotEqual(state_id, next_state)
 
     def test_unavailable_action_penalizes_agent(self) -> None:
-        env = GridWorldEnvironment(width=2, height=2)
+        env = GridWorldEnvironment(width=4, height=4)
         node = MeshtasticNode(
             identifier="node-edge",
             battery_level=60.0,
             compute_efficiency_flops_per_milliamp=8.0,
-            location=GridLocation(0, 0),
+            location=GridLocation(1, 1),
         )
         state_id, updated_node, reward, done = env.step(node, int(Action.MOVE_FORWARD))
         self.assertEqual(state_id, env.encode_state(node.location))

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -18,6 +18,8 @@ def test_snapshot_serializes_to_json() -> None:
     assert payload["grid"]["height"] == 5
     assert len(payload["cats"]) == 2
     assert len(payload["dogs"]) == 1
+    assert len(payload["ascii_map"]) == 5
+    assert all(isinstance(row, str) for row in payload["ascii_map"])
 
 
 def test_agents_remain_within_grid_bounds() -> None:
@@ -28,8 +30,35 @@ def test_agents_remain_within_grid_bounds() -> None:
         cat = snapshot.cats[0]
         dog = snapshot.dogs[0]
 
-        assert 0 <= cat.location.x < 4
-        assert 0 <= cat.location.y < 4
-        assert 0 <= dog.location.x < 4
-        assert 0 <= dog.location.y < 4
+        assert 0 < cat.location.x < 3
+        assert 0 < cat.location.y < 3
+        assert 0 < dog.location.x < 3
+        assert 0 < dog.location.y < 3
+
+
+def test_ascii_map_draws_brown_border() -> None:
+    simulation = MeshSimulation(width=5, height=5, cat_count=1, dog_count=1, random_seed=7)
+
+    snapshot = simulation.snapshot()
+    ascii_map = snapshot.ascii_map
+
+    assert len(ascii_map) == 5
+
+    top_row_tokens = ascii_map[0].split(" ")
+    bottom_row_tokens = ascii_map[-1].split(" ")
+    border_token = top_row_tokens[0]
+
+    assert "\x1b[38;5;94m" in border_token
+    assert border_token.endswith("\x1b[0m")
+    assert all(token == border_token for token in top_row_tokens)
+    assert all(token == border_token for token in bottom_row_tokens)
+
+    for middle_row in ascii_map[1:-1]:
+        tokens = middle_row.split(" ")
+        assert tokens[0] == border_token
+        assert tokens[-1] == border_token
+        assert all(token != border_token for token in tokens[1:-1])
+
+    interior_tokens = [token for row in ascii_map[1:-1] for token in row.split(" ")[1:-1]]
+    assert any(token in {"C", "D"} for token in interior_tokens)
 


### PR DESCRIPTION
## Summary
- add ANSI-colored ASCII border rendering to simulation snapshots
- treat the outermost grid ring as an impassable boundary for cats and dogs
- expand unit tests to cover the border constraints and ASCII output

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d7ffc543c08327949c94028ce5e848