### PR TITLE
Suspend simulation status panel while waiting for live data

### DIFF
--- a/ui/src/scenes/Simulation.js
+++ b/ui/src/scenes/Simulation.js
@@ -1539,6 +1539,20 @@ export class Simulation extends Scene {
             return;
         }
 
+        const shouldSuspendPanel = (
+            this.shouldReceiveRemoteUpdates &&
+            this.isWaitingForData &&
+            !this.isDemoSimulation
+        );
+
+        if (typeof this.statusPanel.setSuspended === 'function') {
+            this.statusPanel.setSuspended(shouldSuspendPanel);
+        }
+
+        if (shouldSuspendPanel) {
+            return;
+        }
+
         const panelData = this.buildStatusPanelData();
 
         if (panelData) {

--- a/ui/src/scenes/SimulationStatusPanel.js
+++ b/ui/src/scenes/SimulationStatusPanel.js
@@ -59,6 +59,7 @@ export class SimulationStatusPanel {
         this.onNodeHoverEnd = onNodeHoverEnd;
         this.isDemo = Boolean(isDemo);
         this.isExpanded = false;
+        this.isSuspended = false;
         this.nodeEntries = new Map();
         this.sortedEntries = [];
         this.panelWidth = MIN_PANEL_WIDTH;
@@ -98,6 +99,20 @@ export class SimulationStatusPanel {
         this.updateLayout();
     }
 
+    setSuspended(isSuspended) {
+        const shouldSuspend = Boolean(isSuspended);
+
+        if (this.isSuspended === shouldSuspend) {
+            return;
+        }
+
+        this.isSuspended = shouldSuspend;
+
+        if (this.container && typeof this.container.setVisible === 'function') {
+            this.container.setVisible(!shouldSuspend);
+        }
+    }
+
     destroy() {
         this.nodeEntries.forEach((entry) => {
             entry.text.destroy();
@@ -113,6 +128,10 @@ export class SimulationStatusPanel {
     }
 
     update(data) {
+        if (this.isSuspended) {
+            return;
+        }
+
         const safeData = data || {};
         this.isDemo = Boolean(safeData.isDemo);
 


### PR DESCRIPTION
## Summary
- add a suspension state to the simulation status panel so it can hide itself
- pause status panel updates while the live data connection is still syncing

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d80696c2c08327bc9e1dc378eeaa4b