### PR TITLE
Add OpenAI background task endpoints

### DIFF
--- a/backend/api/router.py
+++ b/backend/api/router.py
@@ -1,13 +1,15 @@
-"""FastAPI router with websocket support for the Compotastic backend."""
+"""FastAPI router with websocket and background task endpoints for Compotastic."""
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sys
 from pathlib import Path
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import WebSocket, WebSocketDisconnect
 
 BACKEND_ROOT = Path(__file__).resolve().parent.parent
 if str(BACKEND_ROOT) not in sys.path:
@@ -15,9 +17,22 @@ if str(BACKEND_ROOT) not in sys.path:
 
 from simulation.runtime import MeshSimulation
 
+from .tasks import BackgroundTaskManager, ImagePayload, OpenAIImageProcessingService
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+task_manager = BackgroundTaskManager(
+    image_service=OpenAIImageProcessingService(log_callback=logger),
+    log_callback=logger,
+)
+
+
+def get_task_manager() -> BackgroundTaskManager:
+    """Return the configured background task manager."""
+
+    return task_manager
 
 
 @router.get("/health")
@@ -52,3 +67,42 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         logger.exception("Unexpected websocket error: %s", exc)
         await websocket.close(code=1011)
         raise
+
+
+@router.post("/tasks", status_code=status.HTTP_202_ACCEPTED)
+async def create_background_task(
+    metadata: str = Form(..., description="JSON metadata for the OpenAI request"),
+    file: UploadFile = File(..., description="Image file to upload"),
+    manager: BackgroundTaskManager = Depends(get_task_manager),
+) -> dict[str, str]:
+    """Create a background task that uploads an image to OpenAI."""
+
+    try:
+        metadata_payload = json.loads(metadata)
+    except json.JSONDecodeError as exc:
+        logger.debug("Invalid metadata JSON supplied: %s", exc)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid metadata JSON") from exc
+
+    image_bytes = await file.read()
+    if not image_bytes:
+        logger.debug("Empty image upload received for background task")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded image is empty")
+
+    payload = ImagePayload(data=image_bytes, filename=file.filename or "upload.bin", content_type=file.content_type)
+
+    task_id = await manager.create_task(metadata_payload, payload)
+    return {"task_id": task_id}
+
+
+@router.get("/tasks/{task_id}")
+async def get_background_task(
+    task_id: str,
+    manager: BackgroundTaskManager = Depends(get_task_manager),
+) -> dict[str, object]:
+    """Retrieve status for a previously created background task."""
+
+    try:
+        status_payload = await manager.get_status(task_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found") from exc
+    return status_payload

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -1,0 +1,240 @@
+"""In-memory background task management for the FastAPI backend."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+
+class TaskState(str, Enum):
+    """Lifecycle states for a background task."""
+
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass(slots=True)
+class ImagePayload:
+    """Immutable representation of an uploaded image payload."""
+
+    data: bytes
+    filename: str
+    content_type: str | None = None
+
+
+@dataclass(slots=True)
+class TaskInfo:
+    """Metadata tracked for each background task."""
+
+    metadata: dict[str, Any]
+    status: TaskState = TaskState.PENDING
+    result: dict[str, Any] | None = None
+    error: str | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    _completion_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of the task state."""
+
+        payload: dict[str, Any] = {
+            "status": self.status.value,
+            "metadata": self.metadata,
+            "created_at": self.created_at.isoformat() + "Z",
+            "updated_at": self.updated_at.isoformat() + "Z",
+        }
+        if self.result is not None:
+            payload["result"] = self.result
+        if self.error is not None:
+            payload["error"] = self.error
+        return payload
+
+    def mark_processing(self) -> None:
+        self.status = TaskState.PROCESSING
+        self.updated_at = datetime.now(UTC)
+
+    def mark_completed(self, result: dict[str, Any]) -> None:
+        self.status = TaskState.COMPLETED
+        self.result = result
+        self.updated_at = datetime.now(UTC)
+        self._completion_event.set()
+
+    def mark_failed(self, message: str) -> None:
+        self.status = TaskState.FAILED
+        self.error = message
+        self.updated_at = datetime.now(UTC)
+        self._completion_event.set()
+
+
+class ImageProcessingService(Protocol):
+    """Protocol describing an async processor for image tasks."""
+
+    async def generate(self, metadata: dict[str, Any], payload: ImagePayload) -> dict[str, Any]:
+        """Process an image with the provided metadata and return a result."""
+
+
+class ChunkedBytesIO(io.BytesIO):
+    """A ``BytesIO`` wrapper that enforces chunked reads."""
+
+    def __init__(self, data: bytes, chunk_size: int) -> None:
+        super().__init__(data)
+        self._chunk_size = max(1, chunk_size)
+
+    def read(self, size: int = -1) -> bytes:  # noqa: D401 - inherit docstring
+        if size == -1 or size > self._chunk_size:
+            size = self._chunk_size
+        return super().read(size)
+
+
+class OpenAIImageProcessingService:
+    """Adapter that streams uploaded images to the OpenAI Files API."""
+
+    def __init__(
+        self,
+        *,
+        client: "AsyncOpenAI" | None = None,
+        default_model: str = "gpt-4.1-mini",
+        chunk_size: int = 1024 * 1024,
+        log_callback: logging.Logger | None = None,
+    ) -> None:
+        self._client = client
+        self._default_model = default_model
+        self._chunk_size = max(1, chunk_size)
+        self._log = log_callback or logger
+
+    async def generate(self, metadata: dict[str, Any], payload: ImagePayload) -> dict[str, Any]:
+        """Upload an image in chunks and submit it to the OpenAI Responses API."""
+
+        prompt = metadata.get("prompt", "Process image")
+        model = metadata.get("model", self._default_model)
+        chunk_size = int(metadata.get("chunk_size", self._chunk_size))
+
+        self._log.debug("Uploading image '%s' in %d byte chunks", payload.filename, chunk_size)
+
+        client = self._client
+        if client is None:
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI()
+            self._client = client
+
+        stream = ChunkedBytesIO(payload.data, chunk_size)
+        try:
+            upload = await client.files.create(
+                file=(
+                    payload.filename,
+                    stream,
+                    payload.content_type or "application/octet-stream",
+                ),
+                purpose="vision",
+            )
+        finally:
+            stream.close()
+
+        self._log.debug("Image upload complete for file %s (id=%s)", payload.filename, upload.id)
+
+        self._log.debug("Submitting response request to model '%s'", model)
+        response = await client.responses.create(
+            model=model,
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": prompt},
+                        {"type": "input_image", "image_id": upload.id},
+                    ],
+                }
+            ],
+            metadata=metadata,
+        )
+
+        result_payload: dict[str, Any]
+        if hasattr(response, "model_dump"):
+            result_payload = response.model_dump()
+        elif hasattr(response, "dict"):
+            result_payload = response.dict()
+        else:
+            result_payload = json.loads(str(response)) if isinstance(response, str) else {"response": str(response)}
+
+        return {
+            "file_id": getattr(upload, "id", None),
+            "response": result_payload,
+        }
+
+
+class BackgroundTaskManager:
+    """Coordinate execution of in-memory background tasks."""
+
+    def __init__(self, *, image_service: ImageProcessingService, log_callback: logging.Logger | None = None) -> None:
+        self._image_service = image_service
+        self._log = log_callback or logger
+        self._tasks: dict[str, TaskInfo] = {}
+        self._lock = asyncio.Lock()
+
+    async def create_task(
+        self,
+        metadata: dict[str, Any],
+        payload: ImagePayload,
+    ) -> str:
+        """Create a new background task and return its identifier."""
+
+        task_id = uuid4().hex
+        task_info = TaskInfo(metadata=json.loads(json.dumps(metadata)))
+
+        async with self._lock:
+            self._tasks[task_id] = task_info
+
+        self._log.info("Created background task %s", task_id)
+
+        asyncio.create_task(self._run_task(task_id, task_info, payload))
+        return task_id
+
+    async def _run_task(self, task_id: str, task_info: TaskInfo, payload: ImagePayload) -> None:
+        task_info.mark_processing()
+        self._log.debug("Task %s marked as processing", task_id)
+
+        try:
+            result = await self._image_service.generate(task_info.metadata, payload)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            message = str(exc)
+            self._log.exception("Task %s failed: %s", task_id, message)
+            task_info.mark_failed(message)
+        else:
+            self._log.info("Task %s completed", task_id)
+            task_info.mark_completed(result)
+
+    async def get_status(self, task_id: str) -> dict[str, Any]:
+        """Return the latest status for ``task_id``."""
+
+        task = await self._get_task(task_id)
+        return task.snapshot()
+
+    async def wait_for_completion(self, task_id: str, timeout: float | None = None) -> dict[str, Any]:
+        """Block until the specified task completes and return its snapshot."""
+
+        task = await self._get_task(task_id)
+        await asyncio.wait_for(task._completion_event.wait(), timeout=timeout)
+        return task.snapshot()
+
+    async def _get_task(self, task_id: str) -> TaskInfo:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+        if task is None:
+            self._log.debug("Task lookup failed for id %s", task_id)
+            raise KeyError(task_id)
+        return task
+

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,0 +1,124 @@
+"""Tests for the background task manager and API endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import unittest
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from api.app import create_app
+from api.router import get_task_manager
+from api.tasks import BackgroundTaskManager, ImagePayload
+
+
+class _StubImageService:
+    def __init__(self, *, delay: float = 0.0) -> None:
+        self.calls: list[tuple[dict[str, Any], ImagePayload]] = []
+        self.delay = delay
+
+    async def generate(self, metadata: dict[str, Any], payload: ImagePayload) -> dict[str, Any]:
+        self.calls.append((metadata, payload))
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return {
+            "prompt": metadata.get("prompt"),
+            "size": len(payload.data),
+            "filename": payload.filename,
+        }
+
+
+class _FailingImageService:
+    async def generate(self, metadata: dict[str, Any], payload: ImagePayload) -> dict[str, Any]:  # noqa: ARG002
+        raise RuntimeError("boom")
+
+
+class BackgroundTaskManagerTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.logger = logging.getLogger("test.background")
+
+    async def test_create_and_complete_task(self) -> None:
+        service = _StubImageService()
+        manager = BackgroundTaskManager(image_service=service, log_callback=self.logger)
+        payload = ImagePayload(data=b"abc", filename="test.png", content_type="image/png")
+        task_id = await manager.create_task({"prompt": "hello"}, payload)
+
+        status = await manager.wait_for_completion(task_id, timeout=1)
+
+        self.assertEqual(status["status"], "completed")
+        self.assertEqual(status["result"]["size"], 3)
+        self.assertEqual(len(service.calls), 1)
+
+    async def test_task_failure_is_reported(self) -> None:
+        manager = BackgroundTaskManager(image_service=_FailingImageService(), log_callback=self.logger)
+        payload = ImagePayload(data=b"abc", filename="broken.png")
+        task_id = await manager.create_task({}, payload)
+
+        status = await manager.wait_for_completion(task_id, timeout=1)
+        self.assertEqual(status["status"], "failed")
+        self.assertIn("boom", status["error"])
+
+
+class BackgroundTaskApiTests(unittest.TestCase):
+    def setUp(self) -> None:  # noqa: D401
+        service = _StubImageService()
+        self.manager = BackgroundTaskManager(image_service=service, log_callback=logging.getLogger("test.api"))
+        self.app = create_app()
+        self.app.dependency_overrides[get_task_manager] = lambda: self.manager
+        self.client = TestClient(self.app)
+
+    def tearDown(self) -> None:  # noqa: D401
+        self.client.close()
+        self.app.dependency_overrides.pop(get_task_manager, None)
+
+    def test_create_task_endpoint(self) -> None:
+        metadata = {"prompt": "describe"}
+        response = self.client.post(
+            "/tasks",
+            data={"metadata": json.dumps(metadata)},
+            files={"file": ("image.png", b"binary", "image/png")},
+        )
+
+        self.assertEqual(response.status_code, 202)
+        task_id = response.json()["task_id"]
+
+        final_status: dict[str, Any] | None = None
+        for _ in range(50):
+            status_response = self.client.get(f"/tasks/{task_id}")
+            self.assertEqual(status_response.status_code, 200)
+            payload = status_response.json()
+            if payload["status"] in {"completed", "failed"}:
+                final_status = payload
+                break
+            time.sleep(0.01)
+
+        self.assertIsNotNone(final_status)
+        assert final_status is not None
+        self.assertEqual(final_status["status"], "completed")
+        self.assertEqual(final_status["result"]["filename"], "image.png")
+
+    def test_invalid_metadata_returns_400(self) -> None:
+        response = self.client.post(
+            "/tasks",
+            data={"metadata": "not-json"},
+            files={"file": ("image.png", b"data", "image/png")},
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_file_returns_400(self) -> None:
+        response = self.client.post(
+            "/tasks",
+            data={"metadata": json.dumps({})},
+            files={"file": ("image.png", b"", "image/png")},
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_unknown_task_returns_404(self) -> None:
+        response = self.client.get("/tasks/unknown")
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Summary
- add an in-memory background task manager that uploads images to OpenAI using chunked streams
- expose REST endpoints for creating tasks and polling task status in the FastAPI router
- add unit tests covering the task manager and API behaviour

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d80801efe88327adfea1cc0bdcd53b