### PR TITLE
Persist grid world node state between steps

### DIFF
--- a/backend/tests/test_q_learning.py
+++ b/backend/tests/test_q_learning.py
@@ -89,6 +89,21 @@ class GridWorldEnvironmentTests(unittest.TestCase):
         self.assertEqual(reward, -1)
         self.assertFalse(done)
 
+    def test_step_resumes_from_last_tracked_location(self) -> None:
+        env = GridWorldEnvironment(width=5, height=5)
+        node = MeshtasticNode(
+            identifier="node-1",
+            battery_level=80.0,
+            compute_efficiency_flops_per_milliamp=12.0,
+            location=GridLocation(2, 2),
+        )
+
+        _, moved_node, _, _ = env.step(node, int(Action.MOVE_FORWARD))
+        self.assertEqual(moved_node.location, GridLocation(2, 1))
+
+        _, next_node, _, _ = env.step(node, int(Action.MOVE_RIGHT))
+        self.assertEqual(next_node.location, GridLocation(3, 1))
+
 
 class QLearningAgentTests(unittest.TestCase):
     """Confirm the Q-learning agent updates values correctly."""


### PR DESCRIPTION
## Summary
- track each node's last known position inside `GridWorldEnvironment` so actions continue from the updated location
- reuse the tracked node data when resolving actions and add coverage to confirm the environment resumes from the latest position

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d80e68c2c08327a55117a0b049dd6d