### PR TITLE
Add reward tiles to mesh simulation

### DIFF
--- a/backend/simulation/logic/__init__.py
+++ b/backend/simulation/logic/__init__.py
@@ -288,6 +288,24 @@ class GridWorldEnvironment:
 
         return self._rewards.get((location.x, location.y), 0)
 
+    def set_reward(self, location: GridLocation, value: int) -> None:
+        """Assign a reward to the specified interior location."""
+
+        if not isinstance(value, int):
+            raise TypeError("Rewards must be provided as integers")
+        if not self.is_passable(location):
+            raise ValueError("Rewards may only be placed on passable interior tiles")
+        coordinate = (location.x, location.y)
+        if value == 0:
+            self._rewards.pop(coordinate, None)
+        else:
+            self._rewards[coordinate] = value
+
+    def rewards(self) -> Dict[Tuple[int, int], int]:
+        """Return a shallow copy of the configured reward mapping."""
+
+        return dict(self._rewards)
+
     def step(
         self,
         node: MeshtasticNode,

--- a/backend/tests/test_q_learning.py
+++ b/backend/tests/test_q_learning.py
@@ -104,6 +104,23 @@ class GridWorldEnvironmentTests(unittest.TestCase):
         _, next_node, _, _ = env.step(node, int(Action.MOVE_RIGHT))
         self.assertEqual(next_node.location, GridLocation(3, 1))
 
+    def test_set_reward_updates_mapping(self) -> None:
+        env = GridWorldEnvironment(width=5, height=5)
+        location = GridLocation(2, 2)
+
+        env.set_reward(location, 7)
+        self.assertEqual(env.reward_at(location), 7)
+
+        rewards = env.rewards()
+        rewards[(2, 2)] = 99
+        self.assertEqual(env.reward_at(location), 7)
+
+        env.set_reward(location, 0)
+        self.assertEqual(env.reward_at(location), 0)
+
+        with self.assertRaises(ValueError):
+            env.set_reward(GridLocation(0, 0), 5)
+
 
 class QLearningAgentTests(unittest.TestCase):
     """Confirm the Q-learning agent updates values correctly."""

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import json
 
+from simulation.logic import GridLocation
 from simulation.runtime import MeshSimulation
 
 
 def test_snapshot_serializes_to_json() -> None:
-    simulation = MeshSimulation(width=5, height=5, cat_count=2, dog_count=1, random_seed=42)
+    simulation = MeshSimulation(
+        width=5,
+        height=5,
+        cat_count=2,
+        dog_count=1,
+        random_seed=42,
+        reward_tiles=[(2, 2, 3)],
+    )
 
     snapshot = simulation.snapshot()
     encoded = snapshot.to_json()
@@ -18,6 +26,12 @@ def test_snapshot_serializes_to_json() -> None:
     assert payload["grid"]["height"] == 5
     assert len(payload["cats"]) == 2
     assert len(payload["dogs"]) == 1
+    assert payload["rewards"] == [
+        {
+            "location": {"x": 2, "y": 2},
+            "value": 3,
+        }
+    ]
 
 
 def test_agents_remain_within_grid_bounds() -> None:
@@ -32,3 +46,17 @@ def test_agents_remain_within_grid_bounds() -> None:
         assert 0 < cat.location.y < 3
         assert 0 < dog.location.x < 3
         assert 0 < dog.location.y < 3
+
+
+def test_add_reward_tile_updates_environment() -> None:
+    simulation = MeshSimulation(width=5, height=5, cat_count=0, dog_count=0, random_seed=3)
+
+    location = GridLocation(2, 2)
+    simulation.add_reward_tile(location, 4)
+    snapshot = simulation.snapshot()
+
+    assert any(tile.location == location and tile.value == 4 for tile in snapshot.rewards)
+    assert simulation.environment.reward_at(location) == 4
+
+    simulation.add_reward_tile(location, -2)
+    assert simulation.environment.reward_at(location) == -2


### PR DESCRIPTION
## Summary
- add reward tile support to the mesh simulation runtime, including serialization and runtime mutation
- expose reward configuration helpers on the grid world environment for q-learning integration
- extend unit tests to cover reward serialization and environment reward updates

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d810e4aa3c8327b269f60ee10a350b