### PR TITLE
Add node activity log to simulation status panel

### DIFF
--- a/ui/src/scenes/Simulation.js
+++ b/ui/src/scenes/Simulation.js
@@ -338,6 +338,9 @@ class Cat {
         const initialTime = scene.time.now || 0;
         this.scheduleNextBlink(initialTime, { usePhaseOffset: true });
         this.scheduleNextMouthOpen(initialTime, { usePhaseOffset: true });
+        this.movementLog = [];
+        this.maxMovementLogEntries = 40;
+        this.recordMovementLog(`Initialized at (${this.tileX}, ${this.tileY})`, initialTime);
     }
 
     setPosition(tileX, tileY) {
@@ -528,6 +531,7 @@ class Cat {
             return;
         }
 
+        this.recordMovementLog('Scanning for available paths', time);
         const availableDirections = DIRECTIONS.filter((direction) => {
             const nextTileX = this.tileX + direction.x;
             const nextTileY = this.tileY + direction.y;
@@ -540,6 +544,7 @@ class Cat {
         });
 
         if (availableDirections.length === 0) {
+            this.recordMovementLog(`No movement options from (${this.tileX}, ${this.tileY})`, time);
             this.scheduleNextLook(time);
             return;
         }
@@ -548,6 +553,10 @@ class Cat {
 
         this.targetTileX = this.tileX + selectedDirection.x;
         this.targetTileY = this.tileY + selectedDirection.y;
+        this.recordMovementLog(
+            `Planning move toward (${this.targetTileX}, ${this.targetTileY})`,
+            time
+        );
 
         const targetPosition = this.grid.tileToWorld(this.targetTileX, this.targetTileY);
 
@@ -567,6 +576,10 @@ class Cat {
         this.moveStartTime = time;
         this.isMoving = true;
         this.nextLookTime = Number.POSITIVE_INFINITY;
+        this.recordMovementLog(
+            `Started moving toward (${this.targetTileX}, ${this.targetTileY})`,
+            time
+        );
     }
 
     update(time) {
@@ -585,6 +598,10 @@ class Cat {
                 this.isMoving = false;
                 this.setPosition(this.targetTileX, this.targetTileY);
                 this.scheduleNextLook(time);
+                this.recordMovementLog(
+                    `Arrived at (${this.tileX}, ${this.tileY})`,
+                    time
+                );
             }
 
             if (this.modal.visible) {
@@ -623,6 +640,37 @@ class Cat {
     destroy() {
         this.text.destroy();
         this.modal.destroy();
+    }
+
+    recordMovementLog(message, time) {
+        if (typeof message !== 'string' || message.trim().length === 0) {
+            return;
+        }
+
+        const now = Number.isFinite(time) ? time : (this.scene?.time?.now || 0);
+        const entry = {
+            timestamp: now,
+            timeLabel: this.formatMovementLogTime(now),
+            message: message.trim()
+        };
+
+        this.movementLog.push(entry);
+
+        if (this.movementLog.length > this.maxMovementLogEntries) {
+            this.movementLog.splice(0, this.movementLog.length - this.maxMovementLogEntries);
+        }
+    }
+
+    formatMovementLogTime(time) {
+        if (!Number.isFinite(time) || time < 0) {
+            return '0.0s';
+        }
+
+        return `${(time / 1000).toFixed(1)}s`;
+    }
+
+    getMovementLog() {
+        return this.movementLog.map((entry) => ({ ...entry }));
     }
 }
 
@@ -676,6 +724,12 @@ class Dog {
         const initialTime = scene.time.now || 0;
         this.scheduleNextBlink(initialTime, { usePhaseOffset: true });
         this.scheduleNextTongue(initialTime, { usePhaseOffset: true });
+        this.movementLog = [];
+        this.maxMovementLogEntries = 40;
+        this.recordMovementLog(
+            `Initialized at (${this.tileX}, ${this.tileY}) area ${this.tileWidth}x${this.tileHeight}`,
+            initialTime
+        );
     }
 
     computeAreaCenter(tileX, tileY) {
@@ -750,6 +804,10 @@ class Dog {
         this.moveDuration = distance > 0 ? (distance / this.speed) * 1000 : 0;
         this.moveStartTime = time;
         this.isMoving = true;
+        this.recordMovementLog(
+            `Started patrol toward (${this.targetTileX}, ${this.targetTileY})`,
+            time
+        );
     }
 
     buildModalContent() {
@@ -916,6 +974,10 @@ class Dog {
                 this.isMoving = false;
                 this.setPosition(this.targetTileX, this.targetTileY);
                 this.scheduleNextMoveCheck(time);
+                this.recordMovementLog(
+                    `Arrived at (${this.tileX}, ${this.tileY})`,
+                    time
+                );
             }
 
             return;
@@ -931,12 +993,18 @@ class Dog {
         }
 
         this.scheduleNextMoveCheck(time);
+        this.recordMovementLog(
+            `Evaluating patrol options from (${this.tileX}, ${this.tileY})`,
+            time
+        );
 
         if (!cats || cats.length === 0) {
+            this.recordMovementLog('No cats detected — holding position', time);
             return;
         }
 
         if (Phaser.Math.FloatBetween(0, 1) > DOG_MOVE_PROBABILITY) {
+            this.recordMovementLog('Staying put after patrol evaluation', time);
             return;
         }
 
@@ -944,6 +1012,7 @@ class Dog {
         const move = this.determineStepToward(targetCat);
 
         if (!move) {
+            this.recordMovementLog('No viable path toward nearest cat', time);
             return;
         }
 
@@ -965,6 +1034,37 @@ class Dog {
     destroy() {
         this.text.destroy();
         this.modal.destroy();
+    }
+
+    recordMovementLog(message, time) {
+        if (typeof message !== 'string' || message.trim().length === 0) {
+            return;
+        }
+
+        const now = Number.isFinite(time) ? time : (this.scene?.time?.now || 0);
+        const entry = {
+            timestamp: now,
+            timeLabel: this.formatMovementLogTime(now),
+            message: message.trim()
+        };
+
+        this.movementLog.push(entry);
+
+        if (this.movementLog.length > this.maxMovementLogEntries) {
+            this.movementLog.splice(0, this.movementLog.length - this.maxMovementLogEntries);
+        }
+    }
+
+    formatMovementLogTime(time) {
+        if (!Number.isFinite(time) || time < 0) {
+            return '0.0s';
+        }
+
+        return `${(time / 1000).toFixed(1)}s`;
+    }
+
+    getMovementLog() {
+        return this.movementLog.map((entry) => ({ ...entry }));
     }
 }
 
@@ -1830,7 +1930,8 @@ export class Simulation extends Scene {
             tileHeight: 1,
             status,
             displayStatus: status,
-            isActive: this.isCatActive(cat)
+            isActive: this.isCatActive(cat),
+            logEntries: typeof cat.getMovementLog === 'function' ? cat.getMovementLog() : []
         };
     }
 
@@ -1853,7 +1954,8 @@ export class Simulation extends Scene {
             tileHeight: dog.tileHeight,
             status,
             displayStatus: status,
-            isActive: this.isDogActive(dog)
+            isActive: this.isDogActive(dog),
+            logEntries: typeof dog.getMovementLog === 'function' ? dog.getMovementLog() : []
         };
     }
 


### PR DESCRIPTION
## Summary
- track per-step movement activity for cats and dogs and expose the history through node metadata
- add an interactive activity log section to the simulation status panel with UI hints and selection handling
- keep node highlights consistent when toggling logs or collapsing the panel

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d8184a1d208327a4c3320e016b6ab7