### PR TITLE
Add image classification modal for unoccupied grid nodes

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -90,3 +90,219 @@ body {
     justify-content: center;
     align-items: center;
 }
+
+.image-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 6000;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+.image-modal-overlay--visible {
+    display: flex;
+}
+
+.image-modal {
+    width: min(640px, 100%);
+    background: rgba(16, 16, 16, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 12px;
+    box-shadow: 0 22px 40px rgba(0, 0, 0, 0.45);
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    max-height: min(90vh, 720px);
+    overflow: hidden;
+}
+
+.image-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.image-modal__title {
+    margin: 0;
+    font-family: 'Courier', monospace;
+    font-size: 1.3rem;
+    color: #f7f7dc;
+}
+
+.image-modal__close {
+    background: transparent;
+    border: none;
+    color: #f7f7dc;
+    font-size: 1.5rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0.2rem 0.5rem;
+}
+
+.image-modal__close:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+}
+
+.image-modal__form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    flex: 1;
+    overflow: hidden;
+}
+
+.image-modal__label {
+    display: block;
+    font-family: 'Courier', monospace;
+    font-size: 0.95rem;
+    color: #dcd4a0;
+    margin-bottom: 0.4rem;
+}
+
+.image-modal__textarea {
+    width: 100%;
+    min-height: 140px;
+    resize: vertical;
+    padding: 0.75rem;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(10, 10, 10, 0.9);
+    color: #f7f7dc;
+    font-family: 'Courier', monospace;
+    font-size: 0.95rem;
+    box-sizing: border-box;
+}
+
+.image-modal__textarea:disabled {
+    opacity: 0.5;
+}
+
+.image-modal__images {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex: 1;
+    min-height: 200px;
+}
+
+.image-modal__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.75rem;
+    max-height: 260px;
+    overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.image-modal__grid--disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.image-modal__option {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    border: 2px solid transparent;
+    border-radius: 10px;
+    background: rgba(20, 20, 20, 0.9);
+    cursor: pointer;
+    padding: 0.35rem;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.image-modal__option:hover {
+    border-color: rgba(255, 255, 255, 0.4);
+    transform: translateY(-2px);
+}
+
+.image-modal__option--selected {
+    border-color: #f7f7dc;
+    box-shadow: 0 0 0 2px rgba(247, 247, 220, 0.25);
+}
+
+.image-modal__thumbnail {
+    width: 100%;
+    height: 100px;
+    object-fit: cover;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.65);
+}
+
+.image-modal__option-label {
+    font-family: 'Courier', monospace;
+    font-size: 0.75rem;
+    color: #dcd4a0;
+    text-align: center;
+    word-break: break-word;
+}
+
+.image-modal__placeholder {
+    font-family: 'Courier', monospace;
+    font-size: 0.85rem;
+    color: #b8b089;
+    margin: 0;
+}
+
+.image-modal__status {
+    font-family: 'Courier', monospace;
+    font-size: 0.85rem;
+    min-height: 1.2rem;
+    margin: 0;
+    color: #dcd4a0;
+}
+
+.image-modal__status--error {
+    color: #ff9d9d;
+}
+
+.image-modal__status--success {
+    color: #9dffb0;
+}
+
+.image-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.image-modal__button {
+    padding: 0.6rem 1.3rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.1);
+    color: #f7f7dc;
+    font-family: 'Courier', monospace;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.image-modal__button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.image-modal__button--ghost {
+    background: transparent;
+}
+
+.image-modal__button--ghost:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.image-modal__button--primary {
+    background: rgba(34, 139, 230, 0.9);
+    border-color: rgba(34, 139, 230, 0.9);
+}
+
+.image-modal__button--primary:hover:not(:disabled) {
+    background: rgba(34, 139, 230, 1);
+}

--- a/ui/src/api/imageTasks.js
+++ b/ui/src/api/imageTasks.js
@@ -1,0 +1,145 @@
+import { getApiBaseUrl } from '../config';
+
+function normalizePrompt(prompt) {
+    if (typeof prompt !== 'string') {
+        return '';
+    }
+
+    return prompt.trim();
+}
+
+function buildMetadata({ prompt, tileX, tileY, imagePath, imageLabel, filename }) {
+    return {
+        prompt,
+        tile: {
+            x: Number.isFinite(tileX) ? tileX : null,
+            y: Number.isFinite(tileY) ? tileY : null
+        },
+        image: {
+            path: imagePath,
+            label: typeof imageLabel === 'string' ? imageLabel : '',
+            filename
+        },
+        source: 'phaser-grid-selection',
+        createdAt: new Date().toISOString()
+    };
+}
+
+async function loadImageBlob(imagePath) {
+    const response = await fetch(imagePath, { cache: 'no-store' });
+
+    if (!response.ok) {
+        throw new Error(`Unable to load image asset (${response.status} ${response.statusText}).`);
+    }
+
+    return response.blob();
+}
+
+function deriveFilename(imagePath) {
+    if (typeof imagePath !== 'string' || imagePath.trim().length === 0) {
+        return `image-${Date.now()}`;
+    }
+
+    const segments = imagePath.split('/').filter((segment) => segment.trim().length > 0);
+
+    if (segments.length === 0) {
+        return `image-${Date.now()}`;
+    }
+
+    const lastSegment = segments[segments.length - 1];
+
+    return lastSegment || `image-${Date.now()}`;
+}
+
+function ensureFile(blob, filename) {
+    const safeName = filename && filename.trim().length > 0 ? filename : `image-${Date.now()}`;
+    const mimeType = blob.type && blob.type.length > 0 ? blob.type : 'application/octet-stream';
+
+    try {
+        return new File([blob], safeName, { type: mimeType });
+    } catch (error) {
+        return new Blob([blob], { type: mimeType, endings: 'transparent' });
+    }
+}
+
+function buildTasksUrl() {
+    const baseUrl = getApiBaseUrl();
+    const trimmed = typeof baseUrl === 'string' ? baseUrl.trim() : '';
+    const normalized = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+
+    return `${normalized || 'http://localhost:8000'}/tasks`;
+}
+
+export async function submitImageClassificationRequest({
+    imagePath,
+    prompt,
+    tileX,
+    tileY,
+    imageLabel
+}) {
+    const sanitizedPrompt = normalizePrompt(prompt);
+
+    if (!sanitizedPrompt) {
+        throw new Error('Please provide a description for the image classification request.');
+    }
+
+    if (typeof imagePath !== 'string' || imagePath.trim().length === 0) {
+        throw new Error('Please select an image before submitting.');
+    }
+
+    const blob = await loadImageBlob(imagePath);
+    const filename = deriveFilename(imagePath);
+    const fileLike = ensureFile(blob, filename);
+    const metadata = buildMetadata({
+        prompt: sanitizedPrompt,
+        tileX,
+        tileY,
+        imagePath,
+        imageLabel,
+        filename
+    });
+
+    const formData = new FormData();
+    formData.append('metadata', JSON.stringify(metadata));
+
+    if (fileLike instanceof Blob && 'name' in fileLike) {
+        formData.append('file', fileLike, filename);
+    } else {
+        formData.append('file', fileLike, filename);
+    }
+
+    const response = await fetch(buildTasksUrl(), {
+        method: 'POST',
+        body: formData
+    });
+
+    if (!response.ok) {
+        let message = 'Failed to submit image classification request.';
+
+        try {
+            const payload = await response.json();
+
+            if (payload && typeof payload.detail === 'string' && payload.detail.trim().length > 0) {
+                message = payload.detail.trim();
+            }
+        } catch (jsonError) {
+            try {
+                const text = await response.text();
+
+                if (typeof text === 'string' && text.trim().length > 0) {
+                    message = text.trim();
+                }
+            } catch (textError) {
+                // Ignore secondary parsing errors and keep the default message.
+            }
+        }
+
+        throw new Error(message);
+    }
+
+    try {
+        return await response.json();
+    } catch (error) {
+        return {};
+    }
+}

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,4 +1,5 @@
 const DEFAULT_WS_URL = 'ws://localhost:8001/ws';
+const DEFAULT_API_BASE_URL = 'http://localhost:8000';
 
 export function getWebSocketUrl() {
     const configuredUrl = import.meta.env.VITE_WS_URL;
@@ -8,4 +9,14 @@ export function getWebSocketUrl() {
     }
 
     return DEFAULT_WS_URL;
+}
+
+export function getApiBaseUrl() {
+    const configuredUrl = import.meta.env.VITE_API_BASE_URL;
+
+    if (configuredUrl && configuredUrl.trim().length > 0) {
+        return configuredUrl;
+    }
+
+    return DEFAULT_API_BASE_URL;
 }

--- a/ui/src/media/imageOptions.js
+++ b/ui/src/media/imageOptions.js
@@ -1,0 +1,160 @@
+const STATIC_IMAGE_MODULES = import.meta.glob('../assets/**/*.{png,jpg,jpeg,gif,webp,avif}', {
+    eager: true,
+    import: 'default'
+});
+
+function sanitizeOption(entry, fallbackIndex = 0) {
+    if (!entry) {
+        return null;
+    }
+
+    if (typeof entry === 'string') {
+        return {
+            id: `static-${fallbackIndex}`,
+            src: entry,
+            label: `Image ${fallbackIndex + 1}`
+        };
+    }
+
+    if (typeof entry === 'object') {
+        const candidateSrc = typeof entry.src === 'string' ? entry.src : null;
+        const candidatePath = typeof entry.path === 'string' ? entry.path : null;
+        const candidateUrl = typeof entry.url === 'string' ? entry.url : null;
+        const src = candidateSrc || candidatePath || candidateUrl;
+
+        if (!src) {
+            return null;
+        }
+
+        const labelCandidates = [entry.label, entry.title, entry.name];
+        const firstLabel = labelCandidates.find((value) => typeof value === 'string' && value.trim().length > 0);
+        const label = firstLabel || '';
+
+        return {
+            id: typeof entry.id === 'string' && entry.id.trim().length > 0
+                ? entry.id.trim()
+                : `static-${fallbackIndex}`,
+            src,
+            label: label.trim().length > 0 ? label.trim() : `Image ${fallbackIndex + 1}`
+        };
+    }
+
+    return null;
+}
+
+function getBundledOptions() {
+    const entries = Object.entries(STATIC_IMAGE_MODULES || {});
+
+    return entries.map(([path, url], index) => {
+        const normalizedLabel = path
+            .split('/')
+            .filter((segment) => segment.trim().length > 0)
+            .pop() || `Image ${index + 1}`;
+
+        return {
+            id: `bundled-${index}`,
+            src: url,
+            label: normalizedLabel
+        };
+    });
+}
+
+function getGlobalOptions() {
+    if (typeof window === 'undefined') {
+        return [];
+    }
+
+    const globalOptions = window.COMPOTASTIC_IMAGE_OPTIONS;
+
+    if (!Array.isArray(globalOptions)) {
+        return [];
+    }
+
+    return globalOptions
+        .map((entry, index) => sanitizeOption(entry, index))
+        .filter((option) => option && typeof option.src === 'string');
+}
+
+async function fetchManifestOptions(manifestPath = 'assets/manifest.json') {
+    try {
+        const response = await fetch(manifestPath, { cache: 'no-store' });
+
+        if (!response.ok) {
+            return [];
+        }
+
+        const payload = await response.json();
+
+        if (Array.isArray(payload)) {
+            return payload
+                .map((entry, index) => sanitizeOption(entry, index))
+                .filter((option) => option && typeof option.src === 'string');
+        }
+
+        if (payload && Array.isArray(payload.images)) {
+            return payload.images
+                .map((entry, index) => sanitizeOption(entry, index))
+                .filter((option) => option && typeof option.src === 'string');
+        }
+    } catch (error) {
+        // Swallow errors silently so UI can continue functioning without manifest.
+    }
+
+    return [];
+}
+
+function dedupeBySource(options) {
+    const seen = new Set();
+    const deduped = [];
+
+    options.forEach((option) => {
+        if (!option || typeof option.src !== 'string') {
+            return;
+        }
+
+        const key = option.src;
+
+        if (seen.has(key)) {
+            return;
+        }
+
+        seen.add(key);
+        deduped.push(option);
+    });
+
+    return deduped;
+}
+
+let cachedOptionsPromise = null;
+
+export async function loadImageOptions({ refresh = false } = {}) {
+    if (!cachedOptionsPromise || refresh) {
+        cachedOptionsPromise = (async () => {
+            const bundled = getBundledOptions();
+            const globals = getGlobalOptions();
+            const manifest = await fetchManifestOptions();
+            const combined = dedupeBySource([...bundled, ...globals, ...manifest]);
+
+            if (combined.length === 0) {
+                return [];
+            }
+
+            return combined.sort((a, b) => {
+                const labelA = typeof a.label === 'string' ? a.label.toLowerCase() : '';
+                const labelB = typeof b.label === 'string' ? b.label.toLowerCase() : '';
+
+                if (labelA < labelB) {
+                    return -1;
+                }
+
+                if (labelA > labelB) {
+                    return 1;
+                }
+
+                return 0;
+            });
+        })();
+    }
+
+    return cachedOptionsPromise;
+}

--- a/ui/src/modals/ImageClassificationModal.js
+++ b/ui/src/modals/ImageClassificationModal.js
@@ -1,0 +1,420 @@
+import { submitImageClassificationRequest } from '../api/imageTasks';
+import { loadImageOptions } from '../media/imageOptions';
+
+export const DEFAULT_IMAGE_PROMPT = 'This is an image taken from a robots front facing camera, what is the object found in the foreground and classify if this image is dangerous or capable of being moved by a light weight robot. Respond with one of these words only DANGEROUS, MOVABLE, IMMOVABLE, UNKNOWN';
+
+function createElement(tag, className, attributes = {}) {
+    const element = document.createElement(tag);
+
+    if (className) {
+        element.className = className;
+    }
+
+    Object.entries(attributes).forEach(([key, value]) => {
+        if (value === undefined || value === null) {
+            return;
+        }
+
+        element.setAttribute(key, value);
+    });
+
+    return element;
+}
+
+function stopEvent(event) {
+    if (!event) {
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+}
+
+export class ImageClassificationModal {
+    constructor({ defaultPrompt = DEFAULT_IMAGE_PROMPT } = {}) {
+        this.defaultPrompt = defaultPrompt;
+        this.overlay = null;
+        this.form = null;
+        this.promptInput = null;
+        this.gridContainer = null;
+        this.submitButton = null;
+        this.cancelButton = null;
+        this.closeButton = null;
+        this.statusElement = null;
+        this.placeholderElement = null;
+        this.isBusy = false;
+        this.isVisible = false;
+        this.selectedImage = null;
+        this.tileLocation = { x: null, y: null };
+
+        this.handleOverlayClick = this.handleOverlayClick.bind(this);
+        this.handleFormSubmit = this.handleFormSubmit.bind(this);
+        this.handleCancel = this.handleCancel.bind(this);
+        this.handleOptionClick = this.handleOptionClick.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+    }
+
+    ensureElements() {
+        if (this.overlay) {
+            return;
+        }
+
+        this.overlay = createElement('div', 'image-modal-overlay', {
+            role: 'dialog',
+            'aria-modal': 'true',
+            tabindex: '-1'
+        });
+
+        const modal = createElement('div', 'image-modal');
+        const header = createElement('div', 'image-modal__header');
+        const title = createElement('h2', 'image-modal__title');
+        title.textContent = 'Classify selected grid node';
+        this.closeButton = createElement('button', 'image-modal__close', {
+            type: 'button',
+            'aria-label': 'Close classification dialog'
+        });
+        this.closeButton.textContent = '×';
+
+        header.appendChild(title);
+        header.appendChild(this.closeButton);
+
+        this.form = createElement('form', 'image-modal__form');
+        const promptLabel = createElement('label', 'image-modal__label');
+        promptLabel.textContent = 'Describe the classification task';
+        this.promptInput = createElement('textarea', 'image-modal__textarea', {
+            rows: '5',
+            required: 'true'
+        });
+        this.promptInput.value = this.defaultPrompt;
+        promptLabel.appendChild(this.promptInput);
+
+        const imageSection = createElement('div', 'image-modal__images');
+        const imageLabel = createElement('span', 'image-modal__label');
+        imageLabel.textContent = 'Choose a reference image';
+        this.gridContainer = createElement('div', 'image-modal__grid', {
+            role: 'listbox'
+        });
+        this.placeholderElement = createElement('p', 'image-modal__placeholder');
+        this.placeholderElement.textContent = 'No images available. Add files to src/assets or define assets/manifest.json to populate this list.';
+        imageSection.appendChild(imageLabel);
+        imageSection.appendChild(this.gridContainer);
+        imageSection.appendChild(this.placeholderElement);
+
+        this.statusElement = createElement('p', 'image-modal__status', {
+            'aria-live': 'polite'
+        });
+
+        const actions = createElement('div', 'image-modal__actions');
+        this.cancelButton = createElement('button', 'image-modal__button image-modal__button--ghost', {
+            type: 'button'
+        });
+        this.cancelButton.textContent = 'Cancel';
+        this.submitButton = createElement('button', 'image-modal__button image-modal__button--primary', {
+            type: 'submit'
+        });
+        this.submitButton.textContent = 'Send Request';
+
+        actions.appendChild(this.cancelButton);
+        actions.appendChild(this.submitButton);
+
+        this.form.appendChild(promptLabel);
+        this.form.appendChild(imageSection);
+        this.form.appendChild(this.statusElement);
+        this.form.appendChild(actions);
+
+        modal.appendChild(header);
+        modal.appendChild(this.form);
+        this.overlay.appendChild(modal);
+
+        this.overlay.addEventListener('click', this.handleOverlayClick);
+        this.gridContainer.addEventListener('click', this.handleOptionClick);
+        this.closeButton.addEventListener('click', this.handleCancel);
+        this.cancelButton.addEventListener('click', this.handleCancel);
+        this.form.addEventListener('submit', this.handleFormSubmit);
+        document.addEventListener('keydown', this.handleKeyDown);
+
+        document.body.appendChild(this.overlay);
+    }
+
+    async open({ tileX, tileY } = {}) {
+        this.ensureElements();
+
+        if (this.isBusy) {
+            return;
+        }
+
+        if (this.isVisible) {
+            this.focusPrompt();
+            return;
+        }
+
+        this.tileLocation = {
+            x: Number.isFinite(tileX) ? tileX : null,
+            y: Number.isFinite(tileY) ? tileY : null
+        };
+
+        this.promptInput.value = this.defaultPrompt;
+        this.selectedImage = null;
+        this.statusElement.textContent = '';
+        this.statusElement.classList.remove('image-modal__status--error', 'image-modal__status--success');
+        this.overlay.classList.add('image-modal-overlay--visible');
+        this.isVisible = true;
+        this.overlay.focus({ preventScroll: true });
+
+        await this.populateImages();
+        this.focusPrompt();
+    }
+
+    async populateImages() {
+        if (!this.gridContainer) {
+            return;
+        }
+
+        this.gridContainer.innerHTML = '';
+
+        let options = [];
+
+        try {
+            options = await loadImageOptions();
+        } catch (error) {
+            this.setStatus('Unable to load image options. Please try again.', 'error');
+            this.togglePlaceholder(true);
+            return;
+        }
+
+        const limited = Array.isArray(options) ? options.slice(0, 10) : [];
+
+        if (!limited.length) {
+            this.togglePlaceholder(true);
+            return;
+        }
+
+        this.togglePlaceholder(false);
+
+        limited.forEach((option, index) => {
+            if (!option || typeof option.src !== 'string') {
+                return;
+            }
+
+            const button = createElement('button', 'image-modal__option', {
+                type: 'button',
+                role: 'option',
+                'data-src': option.src,
+                'data-label': option.label || '',
+                'aria-label': option.label || `Image ${index + 1}`
+            });
+            const image = createElement('img', 'image-modal__thumbnail', {
+                src: option.src,
+                alt: option.label || `Image ${index + 1}`
+            });
+            const caption = createElement('span', 'image-modal__option-label');
+            caption.textContent = option.label || `Image ${index + 1}`;
+
+            button.appendChild(image);
+            button.appendChild(caption);
+            this.gridContainer.appendChild(button);
+        });
+    }
+
+    focusPrompt() {
+        if (!this.promptInput) {
+            return;
+        }
+
+        this.promptInput.focus({ preventScroll: true });
+        this.promptInput.setSelectionRange(this.promptInput.value.length, this.promptInput.value.length);
+    }
+
+    togglePlaceholder(shouldShow) {
+        if (!this.placeholderElement) {
+            return;
+        }
+
+        this.placeholderElement.style.display = shouldShow ? 'block' : 'none';
+        this.gridContainer.style.display = shouldShow ? 'none' : 'grid';
+    }
+
+    handleOverlayClick(event) {
+        if (event.target === this.overlay && !this.isBusy) {
+            this.close();
+        }
+    }
+
+    handleKeyDown(event) {
+        if (!this.isVisible) {
+            return;
+        }
+
+        if (event.key === 'Escape' && !this.isBusy) {
+            stopEvent(event);
+            this.close();
+        }
+    }
+
+    handleCancel(event) {
+        stopEvent(event);
+
+        if (!this.isBusy) {
+            this.close();
+        }
+    }
+
+    handleOptionClick(event) {
+        const button = event.target.closest('.image-modal__option');
+
+        if (!button || this.isBusy) {
+            return;
+        }
+
+        const previouslySelected = this.gridContainer.querySelector('.image-modal__option--selected');
+
+        if (previouslySelected) {
+            previouslySelected.classList.remove('image-modal__option--selected');
+        }
+
+        button.classList.add('image-modal__option--selected');
+        this.selectedImage = {
+            src: button.getAttribute('data-src'),
+            label: button.getAttribute('data-label')
+        };
+    }
+
+    async handleFormSubmit(event) {
+        stopEvent(event);
+
+        if (this.isBusy) {
+            return;
+        }
+
+        if (!this.selectedImage || !this.selectedImage.src) {
+            this.setStatus('Select an image to continue.', 'error');
+            return;
+        }
+
+        const promptText = this.promptInput.value || '';
+
+        this.setBusy(true);
+        this.setStatus('Submitting request…', 'info');
+
+        try {
+            const response = await submitImageClassificationRequest({
+                imagePath: this.selectedImage.src,
+                prompt: promptText,
+                tileX: this.tileLocation.x,
+                tileY: this.tileLocation.y,
+                imageLabel: this.selectedImage.label
+            });
+
+            const taskId = response && typeof response.task_id === 'string' ? response.task_id : null;
+            const successMessage = taskId
+                ? `Request submitted! Task ID: ${taskId}`
+                : 'Request submitted successfully.';
+
+            this.setStatus(successMessage, 'success');
+            setTimeout(() => this.close(), 1200);
+        } catch (error) {
+            const message = error && typeof error.message === 'string'
+                ? error.message
+                : 'Failed to submit the image classification request.';
+            this.setStatus(message, 'error');
+        } finally {
+            this.setBusy(false);
+        }
+    }
+
+    setBusy(isBusy) {
+        this.isBusy = Boolean(isBusy);
+
+        if (this.submitButton) {
+            this.submitButton.disabled = this.isBusy;
+        }
+
+        if (this.cancelButton) {
+            this.cancelButton.disabled = this.isBusy;
+        }
+
+        if (this.closeButton) {
+            this.closeButton.disabled = this.isBusy;
+        }
+
+        if (this.promptInput) {
+            this.promptInput.disabled = this.isBusy;
+        }
+
+        if (this.gridContainer) {
+            this.gridContainer.classList.toggle('image-modal__grid--disabled', this.isBusy);
+        }
+    }
+
+    setStatus(message, variant = 'info') {
+        if (!this.statusElement) {
+            return;
+        }
+
+        this.statusElement.textContent = message || '';
+        this.statusElement.classList.remove('image-modal__status--error', 'image-modal__status--success');
+
+        if (variant === 'error') {
+            this.statusElement.classList.add('image-modal__status--error');
+        } else if (variant === 'success') {
+            this.statusElement.classList.add('image-modal__status--success');
+        }
+    }
+
+    isOpen() {
+        return Boolean(this.isVisible);
+    }
+
+    close() {
+        if (!this.overlay || !this.isVisible) {
+            return;
+        }
+
+        this.overlay.classList.remove('image-modal-overlay--visible');
+        this.isVisible = false;
+        this.setBusy(false);
+    }
+
+    destroy() {
+        if (!this.overlay) {
+            return;
+        }
+
+        this.overlay.removeEventListener('click', this.handleOverlayClick);
+
+        if (this.gridContainer) {
+            this.gridContainer.removeEventListener('click', this.handleOptionClick);
+        }
+
+        if (this.closeButton) {
+            this.closeButton.removeEventListener('click', this.handleCancel);
+        }
+
+        if (this.cancelButton) {
+            this.cancelButton.removeEventListener('click', this.handleCancel);
+        }
+
+        if (this.form) {
+            this.form.removeEventListener('submit', this.handleFormSubmit);
+        }
+
+        document.removeEventListener('keydown', this.handleKeyDown);
+
+        if (this.overlay.parentNode) {
+            this.overlay.parentNode.removeChild(this.overlay);
+        }
+
+        this.overlay = null;
+        this.form = null;
+        this.promptInput = null;
+        this.gridContainer = null;
+        this.submitButton = null;
+        this.cancelButton = null;
+        this.closeButton = null;
+        this.statusElement = null;
+        this.placeholderElement = null;
+        this.selectedImage = null;
+        this.isVisible = false;
+        this.isBusy = false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a browser modal that opens when clicking an open grid tile so users can edit the default prompt and pick an asset image
- load reference images from bundled assets, optional global configuration, or an assets manifest and submit the selection to the OpenAI task endpoint
- style the new modal overlay and expose an API base URL helper for the frontend

## Testing
- npm run build
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d81f5ff4ec8327811a1ac17d700ec2