### PR TITLE
Enhance simulation agent reward handling and alerts

### DIFF
--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from simulation.logic import Action
 from simulation.logic import GridLocation
 from simulation.logic import QLearningAgent
+from simulation.logic import Surroundings
 from simulation.runtime import MeshSimulation
 
 
@@ -36,6 +37,7 @@ def test_snapshot_serializes_to_json() -> None:
             "value": 3,
         }
     ]
+    assert payload["alerts"] == {}
 
 
 def test_agents_remain_within_grid_bounds() -> None:
@@ -91,7 +93,12 @@ def test_move_node_skips_occupied_tiles_without_side_effects() -> None:
     simulation._rng = ControlledRandom()
 
     with patch.object(simulation._environment, "step", wraps=simulation._environment.step) as step_spy:
-        updated = simulation._move_node(cat, occupied, idle_probability=0.0)
+        updated = simulation._move_node(
+            cat,
+            occupied,
+            agent_type="cat",
+            idle_probability=0.0,
+        )
 
     assert step_spy.call_count == 1
     assert (updated.location.x, updated.location.y) != (2, 1)
@@ -128,9 +135,17 @@ def test_move_node_uses_registered_model_policy() -> None:
         def randrange(self, upper: int) -> int:
             return 0
 
+        def shuffle(self, sequence) -> None:
+            return None
+
     simulation._rng = PredictableRandom()
 
-    updated = simulation._move_node(cat, set(), idle_probability=0.0)
+    updated = simulation._move_node(
+        cat,
+        set(),
+        agent_type="cat",
+        idle_probability=0.0,
+    )
 
     assert updated.location.x == cat.location.x + 1
     assert updated.location.y == cat.location.y
@@ -160,14 +175,125 @@ def test_move_node_requests_model_when_untrained() -> None:
         def randrange(self, upper: int) -> int:
             return 0
 
+        def shuffle(self, sequence) -> None:
+            return None
+
     simulation._rng = PredictableRandom()
 
     with patch.object(simulation._environment, "step", wraps=simulation._environment.step) as step_spy:
-        updated = simulation._move_node(cat, set(), idle_probability=0.0)
+        updated = simulation._move_node(
+            cat,
+            set(),
+            agent_type="cat",
+            idle_probability=0.0,
+        )
 
     assert step_spy.call_count == 1
     _, action = step_spy.call_args[0][0:2]
-    assert action == int(Action.STOP)
-    assert updated.location == cat.location
+    assert action != int(Action.STOP)
+    assert updated.location != cat.location
     assert any("lacks a trained model" in message for message in messages)
     assert any("requesting updated Q-learning model" in message for message in messages)
+
+
+def test_cat_consumes_reward_and_broadcasts_update() -> None:
+    simulation = MeshSimulation(
+        width=5,
+        height=5,
+        cat_count=1,
+        dog_count=0,
+        random_seed=17,
+        reward_tiles=[(2, 2, 4)],
+    )
+
+    messages: list[str] = []
+
+    def capture(message: str) -> None:
+        messages.append(message)
+
+    simulation._log = capture
+
+    cat = simulation.snapshot().cats[0].with_location(GridLocation(2, 2))
+    simulation._cats = [cat]
+    simulation.environment._node_states[cat.identifier] = cat
+
+    class DeterministicRandom:
+        def random(self) -> float:
+            return 0.99
+
+        def uniform(self, start: float, end: float) -> float:
+            return start
+
+        def randrange(self, upper: int) -> int:
+            return 0
+
+        def shuffle(self, sequence) -> None:
+            return None
+
+    simulation._rng = DeterministicRandom()
+
+    updated = simulation._move_node(
+        cat,
+        set(),
+        agent_type="cat",
+        idle_probability=0.0,
+    )
+
+    assert simulation.environment.reward_at(GridLocation(2, 2)) == 0
+    assert all(tile.location != GridLocation(2, 2) for tile in simulation._reward_tiles)
+    assert any("broadcast state update" in message for message in messages)
+    assert updated.location == cat.location
+
+
+def test_dog_without_actions_sets_alert_status() -> None:
+    simulation = MeshSimulation(width=5, height=5, cat_count=0, dog_count=1, random_seed=23)
+
+    messages: list[str] = []
+
+    def capture(message: str) -> None:
+        messages.append(message)
+
+    simulation._log = capture
+
+    dog = simulation.snapshot().dogs[0].with_location(GridLocation(2, 2))
+    simulation._dogs = [dog]
+    simulation.environment._node_states[dog.identifier] = dog
+
+    class DeterministicRandom:
+        def random(self) -> float:
+            return 0.99
+
+        def uniform(self, start: float, end: float) -> float:
+            return start
+
+        def randrange(self, upper: int) -> int:
+            return 0
+
+        def shuffle(self, sequence) -> None:
+            return None
+
+    simulation._rng = DeterministicRandom()
+
+    no_actions = Surroundings(
+        can_move_forward=False,
+        can_move_backward=False,
+        can_move_left=False,
+        can_move_right=False,
+        can_do_work=False,
+        can_stop=False,
+        can_call_for_help=False,
+    )
+
+    with patch.object(simulation._environment, "surroundings_for", return_value=no_actions):
+        with patch.object(simulation._environment, "step", wraps=simulation._environment.step) as step_spy:
+            updated = simulation._move_node(
+                dog,
+                set(),
+                agent_type="dog",
+                idle_probability=0.0,
+            )
+
+    assert step_spy.call_count == 1
+    assert updated.location == dog.location
+    assert simulation.snapshot().alerts.get(dog.identifier)
+    assert any("entered alert state" in message for message in messages)


### PR DESCRIPTION
## Summary
- track simulation alerts in snapshots and expose them to downstream consumers
- ensure cats consume reward tiles, broadcast state updates, and continue working without entering a stop state
- place dogs in alert stop state when no actions are available and cover the new behaviours with unit tests

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d824b44a048327a165545cf0256e3e