### PR TITLE
Enable uploading custom images in modal

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -189,56 +189,56 @@ body {
     flex-direction: column;
     gap: 0.75rem;
     flex: 1;
+}
+
+.image-modal__file-input {
+    display: block;
+    width: 100%;
+    font-family: 'Courier', monospace;
+    font-size: 0.85rem;
+    color: #f7f7dc;
+}
+
+.image-modal__file-input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.image-modal__preview {
+    position: relative;
+    border-radius: 12px;
+    border: 1px dashed rgba(255, 255, 255, 0.25);
+    background: rgba(10, 10, 10, 0.82);
+    padding: 1rem;
     min-height: 200px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.65rem;
+    transition: opacity 0.2s ease;
 }
 
-.image-modal__grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 0.75rem;
-    max-height: 260px;
-    overflow-y: auto;
-    padding-right: 0.25rem;
+.image-modal__preview--empty {
+    border-style: dashed;
 }
 
-.image-modal__grid--disabled {
-    opacity: 0.5;
+.image-modal__preview--disabled {
+    opacity: 0.6;
     pointer-events: none;
 }
 
-.image-modal__option {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    border: 2px solid transparent;
+.image-modal__preview-image {
+    max-width: 100%;
+    max-height: 240px;
     border-radius: 10px;
-    background: rgba(20, 20, 20, 0.9);
-    cursor: pointer;
-    padding: 0.35rem;
-    transition: border-color 0.2s ease, transform 0.2s ease;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.55);
 }
 
-.image-modal__option:hover {
-    border-color: rgba(255, 255, 255, 0.4);
-    transform: translateY(-2px);
-}
-
-.image-modal__option--selected {
-    border-color: #f7f7dc;
-    box-shadow: 0 0 0 2px rgba(247, 247, 220, 0.25);
-}
-
-.image-modal__thumbnail {
-    width: 100%;
-    height: 100px;
-    object-fit: cover;
-    border-radius: 6px;
-    background: rgba(0, 0, 0, 0.65);
-}
-
-.image-modal__option-label {
+.image-modal__preview-filename {
     font-family: 'Courier', monospace;
-    font-size: 0.75rem;
+    font-size: 0.85rem;
     color: #dcd4a0;
     text-align: center;
     word-break: break-word;
@@ -249,6 +249,7 @@ body {
     font-size: 0.85rem;
     color: #b8b089;
     margin: 0;
+    text-align: center;
 }
 
 .image-modal__status {

--- a/ui/src/api/imageTasks.js
+++ b/ui/src/api/imageTasks.js
@@ -70,7 +70,23 @@ function buildTasksUrl() {
     return `${normalized || 'http://localhost:8000'}/tasks`;
 }
 
+function isFileLike(candidate) {
+    if (!candidate) {
+        return false;
+    }
+
+    if (candidate instanceof Blob) {
+        return true;
+    }
+
+    const size = typeof candidate.size === 'number' ? candidate.size : null;
+    const slice = typeof candidate.slice === 'function';
+
+    return Number.isFinite(size) && slice;
+}
+
 export async function submitImageClassificationRequest({
+    file,
     imagePath,
     prompt,
     tileX,
@@ -83,29 +99,53 @@ export async function submitImageClassificationRequest({
         throw new Error('Please provide a description for the image classification request.');
     }
 
-    if (typeof imagePath !== 'string' || imagePath.trim().length === 0) {
-        throw new Error('Please select an image before submitting.');
+    const hasUpload = isFileLike(file);
+    const trimmedPath = typeof imagePath === 'string' ? imagePath.trim() : '';
+
+    if (!hasUpload && trimmedPath.length === 0) {
+        throw new Error('Please select or upload an image before submitting.');
     }
 
-    const blob = await loadImageBlob(imagePath);
-    const filename = deriveFilename(imagePath);
-    const fileLike = ensureFile(blob, filename);
+    let fileLike = null;
+    let filename = '';
+    let metadataPath = '';
+
+    if (hasUpload) {
+        fileLike = file;
+        const candidateName = typeof file.name === 'string' ? file.name : null;
+        filename = candidateName && candidateName.trim().length > 0
+            ? candidateName.trim()
+            : deriveFilename(trimmedPath);
+        metadataPath = '';
+    } else {
+        const blob = await loadImageBlob(trimmedPath);
+        filename = deriveFilename(trimmedPath);
+        fileLike = ensureFile(blob, filename);
+        metadataPath = trimmedPath;
+    }
+
+    const normalizedFilename = filename && filename.trim().length > 0
+        ? filename.trim()
+        : `image-${Date.now()}`;
+    const normalizedLabel = typeof imageLabel === 'string' && imageLabel.trim().length > 0
+        ? imageLabel.trim()
+        : normalizedFilename;
     const metadata = buildMetadata({
         prompt: sanitizedPrompt,
         tileX,
         tileY,
-        imagePath,
-        imageLabel,
-        filename
+        imagePath: metadataPath,
+        imageLabel: normalizedLabel,
+        filename: normalizedFilename
     });
 
     const formData = new FormData();
     formData.append('metadata', JSON.stringify(metadata));
 
-    if (fileLike instanceof Blob && 'name' in fileLike) {
-        formData.append('file', fileLike, filename);
+    if (fileLike instanceof Blob) {
+        formData.append('file', fileLike, normalizedFilename);
     } else {
-        formData.append('file', fileLike, filename);
+        formData.append('file', fileLike, normalizedFilename);
     }
 
     const response = await fetch(buildTasksUrl(), {


### PR DESCRIPTION
## Summary
- replace the preset image selector with a local file upload workflow in the classification modal
- add preview styling for uploaded files and disable states to match the new interaction
- update the image classification request helper to submit uploaded files directly

## Testing
- python -m unittest discover -s tests -p "test_*.py"
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d824dbd95c8327af9c3a27b9561ce0