### PR TITLE
Allow dogs to explore without trained models

### DIFF
--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -54,6 +54,22 @@ def test_agents_remain_within_grid_bounds() -> None:
         assert 0 < dog.location.y < 3
 
 
+def test_dog_without_model_eventually_moves() -> None:
+    simulation = MeshSimulation(width=5, height=5, cat_count=0, dog_count=1, random_seed=7)
+
+    initial = simulation.snapshot().dogs[0].location
+
+    moved = False
+    for _ in range(10):
+        snapshot = simulation.step()
+        current = snapshot.dogs[0].location
+        if current != initial:
+            moved = True
+            break
+
+    assert moved, "Dog should explore the grid even without a trained model"
+
+
 def test_add_reward_tile_updates_environment() -> None:
     simulation = MeshSimulation(width=5, height=5, cat_count=0, dog_count=0, random_seed=3)
 


### PR DESCRIPTION
## Summary
- add a fallback action ordering so untrained nodes keep exploring instead of stopping immediately
- prioritise movement commands over STOP when falling back to locally ranked actions
- cover the behaviour with a regression test that ensures dogs roam without a model

## Testing
- python -m compileall backend
- python -m unittest discover -s tests -p "test_*.py"
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d82a92209c8327919771df7277e391