### PR TITLE
Fix OpenAI image request parameter

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -210,7 +210,10 @@ class OpenAIImageProcessingService:
                     "role": "user",
                     "content": [
                         {"type": "input_text", "text": prompt},
-                        {"type": "input_image", "image_id": upload.id},
+                        {
+                            "type": "input_image",
+                            "image_file": {"file_id": upload.id},
+                        },
                     ],
                 }
             ],


### PR DESCRIPTION
## Summary
- update the OpenAI Responses API payload to reference uploaded images via `image_file`

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d82ec9b7348327a05dd4b046b71aaf