### PR TITLE
Allow mutating simulation dataclasses for webhook updates

### DIFF
--- a/backend/simulation/logic/__init__.py
+++ b/backend/simulation/logic/__init__.py
@@ -19,7 +19,7 @@ from dataclasses_json import dataclass_json
 
 
 @dataclass_json
-@dataclass(frozen=True)
+@dataclass
 class LogicProbe:
     """Lightweight object used to verify simulation logic imports."""
 
@@ -32,7 +32,7 @@ class LogicProbe:
 
 
 @dataclass_json
-@dataclass(frozen=True)
+@dataclass
 class GridLocation:
     """Simple integer based coordinate used to place nodes on a 2D grid."""
 
@@ -78,7 +78,7 @@ def _default_logger(message: str) -> None:
     return None
 
 
-@dataclass(frozen=True)
+@dataclass
 class Surroundings:
     """Represents which integer encoded actions are currently available."""
 
@@ -134,7 +134,7 @@ class Surroundings:
         return [int(action) for action in actions]
 
 
-@dataclass(frozen=True)
+@dataclass
 class NodeState:
     """Encapsulates the location and surroundings for Q-learning."""
 
@@ -152,7 +152,7 @@ class NodeState:
 
 
 @dataclass_json
-@dataclass(frozen=True)
+@dataclass
 class MeshtasticNode:
     """Representation of a Meshtastic node used in the simulation grid."""
 

--- a/backend/simulation/runtime.py
+++ b/backend/simulation/runtime.py
@@ -21,7 +21,7 @@ CoordinateSet = Set[Tuple[int, int]]
 
 
 @dataclass_json
-@dataclass(frozen=True)
+@dataclass
 class SimulationGrid:
     """Dataclass describing the grid used for rendering the map."""
 
@@ -30,7 +30,7 @@ class SimulationGrid:
 
 
 @dataclass_json
-@dataclass(frozen=True)
+@dataclass
 class RewardTile:
     """Serializable description of a reward positioned on the grid."""
 
@@ -39,7 +39,7 @@ class RewardTile:
 
 
 @dataclass_json
-@dataclass(frozen=True)
+@dataclass
 class SimulationSnapshot:
     """Serializable view of the current simulation state."""
 

--- a/backend/tests/test_simulation_runtime.py
+++ b/backend/tests/test_simulation_runtime.py
@@ -70,6 +70,31 @@ def test_dog_without_model_eventually_moves() -> None:
     assert moved, "Dog should explore the grid even without a trained model"
 
 
+def test_snapshot_nodes_allow_location_updates() -> None:
+    simulation = MeshSimulation(width=5, height=5, cat_count=1, dog_count=0, random_seed=19)
+
+    snapshot = simulation.snapshot()
+    cat = snapshot.cats[0]
+
+    target_location = GridLocation(2, 2)
+    if target_location == cat.location:
+        target_location = GridLocation(3, 2)
+
+    cat.location = target_location
+
+    with patch.object(simulation._environment, "step", wraps=simulation._environment.step) as step_spy:
+        simulation.step()
+
+    cat_calls = [
+        call_args
+        for call_args in step_spy.call_args_list
+        if call_args.args[0].identifier == cat.identifier
+    ]
+    assert cat_calls, "Expected environment step to process the updated node"
+    moved_node = cat_calls[0].args[0]
+    assert moved_node.location == target_location
+
+
 def test_add_reward_tile_updates_environment() -> None:
     simulation = MeshSimulation(width=5, height=5, cat_count=0, dog_count=0, random_seed=3)
 


### PR DESCRIPTION
## Summary
- allow the simulation dataclasses to be mutable so webhook handlers can adjust node state
- add a regression test confirming a webhook-style location update is honoured by the environment

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68d82f6714248327a468ca25dc8a061e