### PR TITLE
Start backend debug task without waiting for debugger

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,6 @@
         "debugpy",
         "--listen",
         "5678",
-        "--wait-for-client",
         "-m",
         "uvicorn",
         "backend.api.app:app",
@@ -35,8 +34,8 @@
         ],
         "background": {
           "activeOnStart": true,
-          "beginsPattern": ".*",
-          "endsPattern": "Uvicorn running on"
+          "beginsPattern": "^INFO:.*Started server process",
+          "endsPattern": "^INFO:.*Application startup complete."
         }
       },
       "presentation": {


### PR DESCRIPTION
## Summary
- remove the `--wait-for-client` flag so the FastAPI server starts immediately during the prelaunch task
- wait for Uvicorn startup logs to mark the task ready for attaching the debugger

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d8d21ba13c8327a24ce5d06040f057