### PR TITLE
Add simulated state updates and mesh energy metrics

### DIFF
--- a/mesh_connector/main.py
+++ b/mesh_connector/main.py
@@ -4,15 +4,46 @@ from __future__ import annotations
 
 import argparse
 import logging
+import random
+import sys
+import time
 from contextlib import ExitStack
-from typing import Iterable, List
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Tuple
 
 from google.protobuf.json_format import MessageToDict
 from meshtastic.ble_interface import BLEDevice, BLEInterface
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+try:  # noqa: WPS229 - import guard keeps optional dependency optional at runtime
+    from backend.simulation.logic import (  # type: ignore
+        Action,
+        GridLocation,
+        GridWorldEnvironment,
+        MeshtasticNode,
+    )
+except ImportError as exc:  # pragma: no cover - exercised when backend package is absent
+    Action = GridLocation = GridWorldEnvironment = MeshtasticNode = None  # type: ignore
+    SIMULATION_IMPORT_ERROR: Optional[Exception] = exc
+else:
+    SIMULATION_IMPORT_ERROR = None
+
+from mesh_connector.protos import AddressableMeshData, StateUpdate
+
 LOGGER_NAME = "mesh_connector.main"
 DEFAULT_LOG_LEVEL = "INFO"
 LOG_LEVELS = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
+
+PROTOCOL_VERSION = 1
+APPLICATION_ID = 0x434F4D50  # ASCII 'COMP'
+SOURCE_ADDRESS = 0x000001
+BROADCAST_ADDRESS = 0x000000
+DEFAULT_MESH_DEVICE_COUNT = 30
+SIMULATION_INTERVAL_SECONDS = 2.0
+DEFAULT_MAX_UPDATES = 5
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -109,6 +140,249 @@ def inspect_device(logger: logging.Logger, node_identifier: str) -> None:
                 logger.info("Metadata %s: %s", key, value)
         else:
             logger.info("No metadata was returned by the device.")
+
+        stream_state_updates(interface, logger)
+
+
+def stream_state_updates(
+    interface: BLEInterface,
+    logger: logging.Logger,
+    *,
+    device_count: int = DEFAULT_MESH_DEVICE_COUNT,
+    interval_seconds: float = SIMULATION_INTERVAL_SECONDS,
+    max_updates: Optional[int] = DEFAULT_MAX_UPDATES,
+) -> None:
+    """Generate reinforcement learning updates and transmit them across the mesh."""
+
+    if SIMULATION_IMPORT_ERROR is not None or GridWorldEnvironment is None:
+        logger.error(
+            "Simulation logic could not be loaded: %s", SIMULATION_IMPORT_ERROR
+        )
+        return
+
+    logger.info(
+        "Starting simulated reinforcement learning updates for %s mesh devices.",
+        device_count,
+    )
+    total_bytes = 0
+    updates_sent = 0
+    generator = _generate_state_updates(logger)
+
+    try:
+        for sequence_id, update in enumerate(generator, start=1):
+            if max_updates is not None and sequence_id > max_updates:
+                break
+            state_update, action_value, reward, done = update
+            envelope = AddressableMeshData(
+                protocol_version=PROTOCOL_VERSION,
+                application_id=APPLICATION_ID,
+                source_address=SOURCE_ADDRESS,
+                destination_address=BROADCAST_ADDRESS,
+                sequence_id=sequence_id,
+                state_update=state_update,
+            )
+            payload = envelope.SerializeToString()
+
+            if hasattr(interface, "sendData"):
+                send_callable = interface.sendData
+            elif hasattr(interface, "localNode") and hasattr(interface.localNode, "sendData"):
+                send_callable = interface.localNode.sendData
+            else:  # pragma: no cover - depends on meshtastic runtime availability
+                logger.error("Meshtastic interface does not expose a sendData method")
+                return
+
+            try:
+                send_callable(payload)
+            except Exception as exc:  # pragma: no cover - depends on runtime transport
+                logger.error("Failed to send state update %s: %s", sequence_id, exc)
+                return
+
+            bytes_sent = len(payload)
+            total_bytes += bytes_sent
+            updates_sent = sequence_id
+            action_name = _resolve_action_name(action_value)
+            logger.info(
+                "Sent state update seq=%s action=%s reward=%s done=%s (%s bytes)",
+                sequence_id,
+                action_name,
+                reward,
+                done,
+                bytes_sent,
+            )
+            stats = _calculate_mesh_energy(bytes_sent, device_count)
+            logger.info(
+                "Estimated mesh energy for %s devices: tx=%.6fAh rx=%.6fAh total=%.6fAh",
+                device_count,
+                stats["tx_amp_hours"],
+                stats["rx_amp_hours"],
+                stats["total_amp_hours"],
+            )
+            logger.debug("Transmission statistics: %s", stats)
+            time.sleep(interval_seconds)
+    except KeyboardInterrupt:  # pragma: no cover - manual interruption
+        logger.info("State update streaming interrupted by user")
+
+    logger.info(
+        "Completed transmission of %s simulated state updates (%s bytes total).",
+        updates_sent,
+        total_bytes,
+    )
+
+
+def _generate_state_updates(
+    logger: logging.Logger,
+    *,
+    rng_seed: Optional[int] = None,
+) -> Iterator[Tuple[StateUpdate, int, int, bool]]:
+    """Yield protobuf state updates derived from the simulation environment."""
+
+    if GridWorldEnvironment is None or MeshtasticNode is None:
+        raise RuntimeError("Simulation environment is unavailable")
+
+    rng = random.Random(rng_seed)
+    environment, node = _create_environment(logger)
+    prior_state = environment.encode_state(node.location)
+
+    while True:
+        surroundings = environment.surroundings_for(node.location)
+        available_actions = surroundings.available_actions()
+        selectable_actions = [
+            action for action in available_actions if action != int(Action.STOP)
+        ]
+        if not selectable_actions:
+            selectable_actions = available_actions
+
+        if not selectable_actions:
+            logger.warning(
+                "No available actions for node %s; resetting simulation environment",
+                node.identifier,
+            )
+            environment, node = _create_environment(logger)
+            prior_state = environment.encode_state(node.location)
+            continue
+
+        action_value = rng.choice(selectable_actions)
+        next_state_id, updated_node, reward, done = environment.step(
+            node, action_value
+        )
+        packed_transition = _pack_transition(
+            updated_node.location, action_value, reward, done
+        )
+        state_update = StateUpdate(
+            packed_transition=packed_transition,
+            prior_state_id=prior_state,
+            next_state_id=next_state_id,
+        )
+        action_name = _resolve_action_name(action_value)
+        logger.debug(
+            "Simulated transition: prior=%s next=%s action=%s reward=%s done=%s",
+            prior_state,
+            next_state_id,
+            action_name,
+            reward,
+            done,
+        )
+
+        yield state_update, action_value, reward, done
+
+        node = updated_node
+        prior_state = next_state_id
+
+        if done:
+            logger.info(
+                "Simulation reached terminal condition; reinitialising environment."
+            )
+            environment, node = _create_environment(logger)
+            prior_state = environment.encode_state(node.location)
+
+
+def _create_environment(logger: logging.Logger) -> Tuple[GridWorldEnvironment, MeshtasticNode]:
+    """Construct a fresh grid environment and simulated mesh node."""
+
+    if GridWorldEnvironment is None or MeshtasticNode is None:
+        raise RuntimeError("Simulation environment is unavailable")
+
+    rewards = {
+        (3, 3): 8,
+        (8, 8): 5,
+        (5, 7): -3,
+    }
+    environment = GridWorldEnvironment(
+        12,
+        12,
+        rewards=rewards,
+        log_callback=logger.debug,
+    )
+    node = MeshtasticNode(
+        identifier="sim-node-1",
+        battery_level=96.0,
+        compute_efficiency_flops_per_milliamp=12_500.0,
+        location=GridLocation(6, 6),
+    )
+    return environment, node
+
+
+def _pack_transition(
+    location: GridLocation,
+    action_value: int,
+    reward: int,
+    done: bool,
+) -> int:
+    """Pack the transition details into the fixed width protobuf field."""
+
+    x = max(0, min(1023, int(location.x)))
+    y = max(0, min(1023, int(location.y)))
+    action_bits = int(action_value) & 0b111
+    done_bit = 1 if done else 0
+    reward_clamped = max(-128, min(127, int(reward)))
+    reward_bits = reward_clamped & 0xFF
+    return (
+        x
+        | (y << 10)
+        | (action_bits << 20)
+        | (done_bit << 23)
+        | (reward_bits << 24)
+    )
+
+
+def _calculate_mesh_energy(
+    bytes_sent: int,
+    device_count: int,
+    *,
+    data_rate_bps: float = 9600.0,
+    tx_current_ma: float = 120.0,
+    rx_current_ma: float = 45.0,
+) -> dict[str, float]:
+    """Estimate amp-hour usage for transmitting payloads across the mesh."""
+
+    if device_count < 1:
+        raise ValueError("device_count must be a positive integer")
+    if data_rate_bps <= 0:
+        raise ValueError("data_rate_bps must be positive")
+
+    bits_sent = bytes_sent * 8
+    tx_time_seconds = bits_sent / data_rate_bps
+    rx_time_seconds = tx_time_seconds * max(device_count - 1, 0)
+    tx_amp_hours = (tx_current_ma / 1000.0) * (tx_time_seconds / 3600.0)
+    rx_amp_hours = (rx_current_ma / 1000.0) * (rx_time_seconds / 3600.0)
+    total_amp_hours = tx_amp_hours + rx_amp_hours
+    return {
+        "bits_sent": float(bits_sent),
+        "tx_time_seconds": float(tx_time_seconds),
+        "rx_time_seconds": float(rx_time_seconds),
+        "tx_amp_hours": float(tx_amp_hours),
+        "rx_amp_hours": float(rx_amp_hours),
+        "total_amp_hours": float(total_amp_hours),
+    }
+
+
+def _resolve_action_name(action_value: int) -> str:
+    """Return a human readable action name for logging purposes."""
+
+    if Action is None:
+        return str(action_value)
+    member = Action._value2member_map_.get(int(action_value))  # type: ignore[attr-defined]
+    return member.name if member is not None else str(action_value)
 
 
 def main() -> None:

--- a/mesh_connector/protos/__init__.py
+++ b/mesh_connector/protos/__init__.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .mesh_connector_pb2 import AddressableMeshData, StateUpdate
+
 # Provide runtime access to the raw .proto file so tooling can locate and compile
 # it without needing hard coded paths within the repository tree.
 PROTO_ROOT = Path(__file__).resolve().parent
 MESH_CONNECTOR_PROTO = PROTO_ROOT / "mesh_connector.proto"
 
-__all__ = ["PROTO_ROOT", "MESH_CONNECTOR_PROTO"]
+__all__ = [
+    "PROTO_ROOT",
+    "MESH_CONNECTOR_PROTO",
+    "AddressableMeshData",
+    "StateUpdate",
+]

--- a/mesh_connector/protos/mesh_connector_pb2.py
+++ b/mesh_connector/protos/mesh_connector_pb2.py
@@ -1,0 +1,131 @@
+"""Lightweight runtime protobuf bindings for the Compotastic mesh connector."""
+
+from __future__ import annotations
+
+from google.protobuf import descriptor_pb2 as _descriptor_pb2
+from google.protobuf import descriptor_pool as _descriptor_pool
+from google.protobuf import message as _message
+from google.protobuf import reflection as _reflection
+from google.protobuf import symbol_database as _symbol_database
+
+_sym_db = _symbol_database.Default()
+
+_FILE_NAME = "mesh_connector.proto"
+
+
+def _build_file_descriptor() -> None:
+    """Register the mesh connector proto definitions with the descriptor pool."""
+
+    pool = _descriptor_pool.Default()
+    try:
+        pool.FindFileByName(_FILE_NAME)
+        return
+    except KeyError:
+        pass
+
+    file_proto = _descriptor_pb2.FileDescriptorProto()
+    file_proto.name = _FILE_NAME
+    file_proto.package = "compotastic.mesh"
+    file_proto.syntax = "proto3"
+    file_proto.dependency.append("meshtastic/mesh.proto")
+
+    state_update = file_proto.message_type.add()
+    state_update.name = "StateUpdate"
+
+    field = state_update.field.add()
+    field.name = "packed_transition"
+    field.number = 1
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_FIXED32
+
+    field = state_update.field.add()
+    field.name = "prior_state_id"
+    field.number = 2
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = state_update.field.add()
+    field.name = "next_state_id"
+    field.number = 3
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    addressable = file_proto.message_type.add()
+    addressable.name = "AddressableMeshData"
+
+    field = addressable.field.add()
+    field.name = "protocol_version"
+    field.number = 1
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = addressable.field.add()
+    field.name = "application_id"
+    field.number = 2
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = addressable.field.add()
+    field.name = "source_address"
+    field.number = 3
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = addressable.field.add()
+    field.name = "destination_address"
+    field.number = 4
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = addressable.field.add()
+    field.name = "sequence_id"
+    field.number = 5
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    payload_oneof = addressable.oneof_decl.add()
+    payload_oneof.name = "payload"
+
+    field = addressable.field.add()
+    field.name = "state_update"
+    field.number = 16
+    field.label = _descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = _descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE
+    field.type_name = ".compotastic.mesh.StateUpdate"
+    field.oneof_index = 0
+
+    pool.Add(file_proto)
+
+
+_build_file_descriptor()
+
+DESCRIPTOR = _descriptor_pool.Default().FindFileByName(_FILE_NAME)
+
+STATEUPDATE = DESCRIPTOR.message_types_by_name["StateUpdate"]
+ADDRESSABLEMESHDATA = DESCRIPTOR.message_types_by_name["AddressableMeshData"]
+
+
+StateUpdate = _reflection.GeneratedProtocolMessageType(
+    "StateUpdate",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": STATEUPDATE,
+        "__module__": __name__,
+    },
+)
+_sym_db.RegisterMessage(StateUpdate)
+
+
+AddressableMeshData = _reflection.GeneratedProtocolMessageType(
+    "AddressableMeshData",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": ADDRESSABLEMESHDATA,
+        "__module__": __name__,
+    },
+)
+_sym_db.RegisterMessage(AddressableMeshData)
+
+
+__all__ = ["AddressableMeshData", "StateUpdate"]
+


### PR DESCRIPTION
## Summary
- add runtime protobuf bindings so the connector can construct AddressableMeshData state updates
- extend the BLE connector to run the backend simulation, publish state updates over the mesh, and log energy usage statistics for a 30-node network
- expose protobuf helpers via mesh_connector.protos for easier imports

## Testing
- python -m unittest discover -s tests -p "test_*.py"

------
https://chatgpt.com/codex/tasks/task_e_68d8dc82735483278470f44eb7d07692